### PR TITLE
Fix multiPodPerHost helm char default override

### DIFF
--- a/helm-charts/aerospike-cluster/templates/aerospike-cluster-cr.yaml
+++ b/helm-charts/aerospike-cluster/templates/aerospike-cluster-cr.yaml
@@ -15,7 +15,7 @@ spec:
   image: {{ .Values.image.repository | default "aerospike/aerospike-server-enterprise" }}:{{ .Values.image.tag | default "5.5.0.7" }}
 
   # Multi pod per host
-  multiPodPerHost: {{ .Values.multiPodPerHost | default true }}
+  multiPodPerHost: {{ .Values.multiPodPerHost | default false }}
 
   # Aerospike access control configuration
   {{- with .Values.aerospikeAccessControl }}


### PR DESCRIPTION
  - In aerospike cluster helm chart the value of multiPodPerHost
    true if not defined: {{ .Values.multiPodPerHost | default true }}
  - When the value of multiPodPerHost is set to false in a chart,
    the value defined about gives true.
  - To fix that, this change set the attribute in values.yaml to
    true.

Signed-off-by: Jean-Francois Weber-Marx <jf.webermarx@criteo.com>