### PR TITLE
Add envar to enable TLS on all racks except rack 0

### DIFF
--- a/pkg/controller/aerospikecluster/controller_helper.go
+++ b/pkg/controller/aerospikecluster/controller_helper.go
@@ -91,7 +91,7 @@ func (r *ReconcileAerospikeCluster) createStatefulSet(aeroCluster *aerospikev1al
 		newEnvVarStatic("MY_POD_CLUSTER_NAME", aeroCluster.Name),
 	}
 
-	if name := getServiceTLSName(aeroCluster); name != "" {
+	if name := getServiceTLSName(aeroCluster); name != "" || IsTlsEnabledOnRacks() {
 		envVarList = append(envVarList, newEnvVarStatic("MY_POD_TLS_ENABLED", "true"))
 	}
 
@@ -1416,4 +1416,14 @@ func GetAerospikeServerInitContainerImage(aeroCluster *aerospikev1alpha1.Aerospi
 	logger.Info(fmt.Sprintf("%s set, using %s for init container image",
 		utils.AerospikeServerInitContainerImageEnvVar, image))
 	return image
+}
+
+func IsTlsEnabledOnRacks() bool {
+	val, found := os.LookupEnv(utils.AerospikeServerTlsEnabledOnlyOnRacksEnvVar)
+	if found {
+		pkglog.Debug(fmt.Sprintf("%s set to %s", utils.AerospikeServerTlsEnabledOnlyOnRacksEnvVar, val))
+		return val == "True"
+	}
+	pkglog.Debug(fmt.Sprintf("%s not set", utils.AerospikeServerTlsEnabledOnlyOnRacksEnvVar))
+	return false
 }

--- a/pkg/controller/configmap/configdata.go
+++ b/pkg/controller/configmap/configdata.go
@@ -388,7 +388,7 @@ servicePort = os.environ['MAPPED_PORT']
 
 if 'MY_POD_TLS_ENABLED' in os.environ and "true" == os.environ['MY_POD_TLS_ENABLED']:
   podPort = os.environ['POD_TLSPORT']
-  servicePort = os.environ['MAPPED_TLSPORT']
+  servicePort = os.environ['MAPPED_TLSPORT'] if os.environ['MAPPED_TLSPORT'] else os.environ['MAPPED_PORT']
 
 # Get AerospikeConfingHash and NetworkPolicyHash
 confHashFile = '/configs/aerospikeConfHash'

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -58,10 +58,11 @@ const (
 )
 
 const (
-	AerospikeServerContainerName     string = "aerospike-server"
-	AerospikeServerInitContainerName string = "aerospike-init"
-	AerospikeServerInitContainerImageEnvVar string = "AEROSPIKE_KUBERNETES_INIT_IMAGE"
-	AerospikeServerInitContainerDefaultImage string = "aerospike/aerospike-kubernetes-init:0.0.12"
+	AerospikeServerContainerName               string = "aerospike-server"
+	AerospikeServerInitContainerName           string = "aerospike-init"
+	AerospikeServerInitContainerImageEnvVar    string = "AEROSPIKE_KUBERNETES_INIT_IMAGE"
+	AerospikeServerInitContainerDefaultImage   string = "aerospike/aerospike-kubernetes-init:0.0.12"
+	AerospikeServerTlsEnabledOnlyOnRacksEnvVar string = "AEROSPIKE_KUBERNETES_TLS_ENABLED_ONLY_ON_RACKS"
 )
 
 // ClusterNamespacedName return namespaced name


### PR DESCRIPTION
As of now to enable TLS on an Aerospike k8s cluster, TLS must be enabled on the default (rack 0) configuration. This causes two concerns:

- To modify the default (rack 0) configuration, the cluster must be fully deleted
- Operator fails because it does not support encrypted private key (ecdsa) when configured on the default rack

This change uses a envar AEROSPIKE_KUBERNETES_TLS_ENABLED_ONLY_ON_RACKS  that, when set to True tls is enabled even if no tls-name is set in the default configuration)
Also in the startup script than runs on the init container we make sure we use a valid service port