### PR TITLE
Align version parsing with our version management

### DIFF
--- a/api/v1beta1/aerospikecluster_validating_webhook.go
+++ b/api/v1beta1/aerospikecluster_validating_webhook.go
@@ -46,7 +46,7 @@ var immutableNetworkParams = []string{
 	"tls-alternate-access-port",
 }
 
-var versionPrefixRegex = regexp.MustCompile("^.*-")
+var versionPrefixRegex = regexp.MustCompile("-.*$")
 
 // +kubebuilder:webhook:path=/validate-asdb-aerospike-com-v1beta1-aerospikecluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=asdb.aerospike.com,resources=aerospikeclusters,verbs=create;update,versions=v1beta1,name=vaerospikecluster.kb.io,admissionReviewVersions={v1,v1beta1}
 


### PR DESCRIPTION
Current parsing remove all values from start to last - while on our versioning the aerospike cluster
release is at the beginning