### PR TITLE
initializedVolumePaths must not be null

### DIFF
--- a/controllers/scripts/create_pod_status_patch.py
+++ b/controllers/scripts/create_pod_status_patch.py
@@ -170,7 +170,7 @@ value = {
         'tlsName': os.environ.get('MY_POD_TLS_NAME', '')
     },
     'initializedVolumes': initialized,
-    'initializedVolumePaths': None,
+    'initializedVolumePaths': [],
     'aerospikeConfigHash': confHash,
     'networkPolicyHash': networkPolicyHash,
     'podSpecHash': podSpecHash,


### PR DESCRIPTION
crd define it as a list of string so trying to initializing it at None failed

```
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {
    
  },
  "status": "Failure",
  "message": "AerospikeCluster.asdb.aerospike.com \"aerospikes99\" is invalid: status.pods.aerospikes99-21-0.initializedVolumePaths: Invalid value: \"null\": status.pods.aerospikes99-21-0.initializedVolumePaths in body must be of type array: \"null\"",
  "reason": "Invalid",
  "details": {
    "name": "aerospikes99",
    "group": "asdb.aerospike.com",
    "kind": "AerospikeCluster",
    "causes": [
      {
        "reason": "FieldValueInvalid",
        "message": "Invalid value: \"null\": status.pods.aerospikes99-21-0.initializedVolumePaths in body must be of type array: \"null\"",
        "field": "status.pods.aerospikes99-21-0.initializedVolumePaths"
      }
    ]
  },
  "code": 422
}
```