### PR TITLE
Prevent user deletion to avoid client ldap error

### DIFF
--- a/pkg/controller/asconfig/access_control_reconcile.go
+++ b/pkg/controller/asconfig/access_control_reconcile.go
@@ -182,11 +182,15 @@ func reconcileUsers(desired map[string]aerospikev1alpha1.AerospikeUserSpec, curr
 	userReconcileCmds := []AerospikeAccessControlReconcileCmd{}
 
 	// Create a list of user commands to drop.
-	usersToDrop := sliceSubtract(currentUserNames, requiredUserNames)
-
-	for _, userToDrop := range usersToDrop {
-		userReconcileCmds = append(userReconcileCmds, AerospikeUserDrop{name: userToDrop})
-	}
+	//
+	// Criteo is using only LDAP users for its applications
+	// These LDAP users should not be dropped, so the loop below is commented
+	//
+	//usersToDrop := sliceSubtract(currentUserNames, requiredUserNames)
+	//
+	//for _, userToDrop := range usersToDrop {
+	//	userReconcileCmds = append(userReconcileCmds, AerospikeUserDrop{name: userToDrop})
+	//}
 
 	// Admin user update command should be execute last to ensure admin password
 	// update does not disrupt reconciliation.


### PR DESCRIPTION
  - When the operator performs user reconciliation it deletes all users not in the spec, but ldap users are (by definition) not in the spec. When ldap users are detected, it can lead to a situation where some are not recreated when a client is using them. This leads to "Not authenticated" errors that clients have hard time to recover (if/when they do)
  - To avoid this issue, we just comment the code that deletes users