### PR TITLE
 Prevent user deletion to avoid client ldap error

### DIFF
--- a/controllers/access_control.go
+++ b/controllers/access_control.go
@@ -215,14 +215,21 @@ func reconcileUsers(
 
 	var userReconcileCmds []AerospikeAccessControlReconcileCmd
 
+	// When the operator performs user reconciliation it
+	// deletes all users not in the spec, but ldap users
+	// are (by definition) not in the spec. When ldap users
+	// are detected, it can lead to a situation where it is
+	// not recreated when a client is using it. This lead
+	// to "Not authenticated" error that clients have hard
+	// time to recover (if/when they do)
 	// Create a list of user commands to drop.
-	usersToDrop := SliceSubtract(currentUserNames, requiredUserNames)
-
-	for _, userToDrop := range usersToDrop {
-		userReconcileCmds = append(
-			userReconcileCmds, AerospikeUserDrop{name: userToDrop},
-		)
-	}
+	//usersToDrop := SliceSubtract(currentUserNames, requiredUserNames)
+	//
+	//for _, userToDrop := range usersToDrop {
+	//	userReconcileCmds = append(
+	//		userReconcileCmds, AerospikeUserDrop{name: userToDrop},
+	//	)
+	//}
 
 	// Admin user update command should be executed last to ensure admin password
 	// update does not disrupt reconciliation.


### PR DESCRIPTION
  - When the operator performs user reconciliation it
    deletes all users not in the spec, but ldap users
    are (by definition) not in the spec. When ldap users
    are detected, it can lead to a situation where it is
    not recreated when a client is using it. This lead
    to "Not authenticated" error that clients have hard
    time to recover (if/when they do)
  - To avoid this issue, we just comment the code that
    deletes users

CHerry-pick from 5edecf2447029829e83e82536370b48142a701ae