### PR TITLE
Add the possibility for alternate rack ids

### DIFF
--- a/controllers/scripts/create-aerospike-conf.sh
+++ b/controllers/scripts/create-aerospike-conf.sh
@@ -31,7 +31,13 @@ PEERS=/etc/aerospike/peers
 # Update node and rack ids configuration file
 # ------------------------------------------------------------------------------
 sed -i "s/ENV_NODE_ID/${NODE_ID}/" ${CFG}
-sed -i "s/rack-id.*0/rack-id    ${RACK_ID}/" ${CFG}
+
+ALTERNATE_RACK_ID="$(curl -f --cacert $CA_CERT -H "Authorization: Bearer $TOKEN" "$KUBE_API_SERVER/api/v1/nodes/$MY_NODE_NAME" | awk '/aerospike.com\/alternate-rack-id/ {gsub(/"|,/,"",$2); print ($2) + 0}')"
+if [ "$ALTERNATE_RACK_ID" == "0" ] || [ "$ALTERNATE_RACK_ID" == "" ]; then
+  sed -i "s/rack-id.*0/rack-id    ${RACK_ID}/" ${CFG}
+else
+  sed -i "s/rack-id.*0/rack-id    ${ALTERNATE_RACK_ID}/" ${CFG}
+fi
 
 echo "" > $GENERATED_ENV
 

--- a/controllers/statefulset.go
+++ b/controllers/statefulset.go
@@ -113,6 +113,7 @@ func (r *SingleClusterReconciler) createSTS(
 		newSTSEnvVar("MY_POD_NAMESPACE", "metadata.namespace"),
 		newSTSEnvVar("MY_POD_IP", "status.podIP"),
 		newSTSEnvVar("MY_HOST_IP", "status.hostIP"),
+		newSTSEnvVar("MY_NODE_NAME", "spec.nodeName"),
 		newSTSEnvVarStatic("MY_POD_TLS_NAME", tlsName),
 		newSTSEnvVarStatic("MY_POD_CLUSTER_NAME", r.aeroCluster.Name),
 	}


### PR DESCRIPTION
  - when the label "aerospike.com/alternate-rack-id" is set at
    the node level, it used in the Aerospike configuration
    (/etc/aerospike/aerospike.conf) as rack-id
  - the Aerospike node id is also updates with the alternate rack
    id using the pattern {rack-id}a{pod-ordinal} already in use
  - to achieve this a new env var containing the node name was added;
    using the kubernetes api in the init scripts (running on the init
    container) the "aerospike.com/alternate-rack-id" label is retrieved
  - if such label does not exist (or is not an integer) the behaviour
    does not change

Cherry-pick of 545cf909a1eb99829b7f5fb89ad664f279da8a0a