### PR TITLE
Allow the addition of a new persistent namespace and new devices to storage-engine of an existing namespace

### DIFF
--- a/api/v1beta1/aerospikecluster_validating_webhook.go
+++ b/api/v1beta1/aerospikecluster_validating_webhook.go
@@ -1063,7 +1063,6 @@ func validateNsConfUpdate(
 				)
 			}
 
-			// Add oldSingleConf ns device list into deviceList if not already present
 			// Keep track of devices referenced in existing namespaces.
 			oldConfStorage := oldSingleConf["storage-engine"].(map[string]interface{})
 			oldConfDevices := oldConfStorage["devices"].([]string)
@@ -1108,7 +1107,7 @@ func validateNsConfUpdate(
 						oldSingleConf, singleConf,
 					)
 				}
-				err := validateStorageConfiguration(oldStorage, storage, singleConf["name"].(string))
+				err := validateStorageEngineConfiguration(oldStorage, storage, singleConf["name"].(string))
 				if ok1 && ok2 && err != nil {
 					return fmt.Errorf("%v", err)
 				}
@@ -1449,17 +1448,19 @@ func ValidateAerospikeObjectMeta(aerospikeObjectMeta *AerospikeObjectMeta) error
 	return nil
 }
 
-// validateStorageConfiguration returns an error if:
+// validateStorageEngineConfiguration returns an error if:
 // -) the type of storage is not the same for old and new storage configuration.
 // -) new devices have been deleted from the new storage configuration.
 // -) new devices are used more than once in the same namespace.
-func validateStorageConfiguration(
-	oldStorage map[string]interface{}, newStorage map[string]interface{},
+func validateStorageEngineConfiguration(
+	oldStorage interface{}, newStorage interface{},
 	namespace string,
 ) error {
+	oldStorageToMap := oldStorage.(map[string]interface{})
+	newStoragetoMap := newStorage.(map[string]interface{})
 
-	oldStorageType := oldStorage["type"].(string)
-	newStorageType := newStorage["type"].(string)
+	oldStorageType := oldStorageToMap["type"].(string)
+	newStorageType := newStoragetoMap["type"].(string)
 
 	if oldStorageType != newStorageType {
 		return fmt.Errorf(
@@ -1468,8 +1469,8 @@ func validateStorageConfiguration(
 		)
 	}
 
-	oldStorageDevices := oldStorage["devices"].([]string)
-	newStorageDevices := newStorage["devices"].([]string)
+	oldStorageDevices := oldStorageToMap["devices"].([]string)
+	newStorageDevices := newStoragetoMap["devices"].([]string)
 
 	// Store new devices to a map(key=device, value=number of time the device exists in the namespace).
 	newDeviceList := map[string]int{}

--- a/api/v1beta1/aerospikecluster_validating_webhook.go
+++ b/api/v1beta1/aerospikecluster_validating_webhook.go
@@ -1099,8 +1099,8 @@ func validateNsConfUpdate(
 				}
 
 				// storage-engine update not allowed for now
-				storage, ok1 := singleConf["storage-engine"].(map[string]interface{})
-				oldStorage, ok2 := oldSingleConf["storage-engine"].(map[string]interface{})
+				storage, ok1 := singleConf["storage-engine"]
+				oldStorage, ok2 := oldSingleConf["storage-engine"]
 				if ok1 && !ok2 || !ok1 && ok2 {
 					return fmt.Errorf(
 						"storage-engine config cannot be added or removed from existing cluster. Old namespace config %v, new namespace config %v",

--- a/api/v1beta1/aerospikecluster_validating_webhook.go
+++ b/api/v1beta1/aerospikecluster_validating_webhook.go
@@ -1107,10 +1107,9 @@ func validateNsConfUpdate(
 					newStorageEngineConf := storage.(map[string]interface{})
 					err := validateStorageEngineConfUpdate(&oldStorageEngineConf, &newStorageEngineConf, singleConf["name"].(string))
 					if err != nil {
-						return fmt.Errorf("%v", err)
+						return err
 					}
 				}
-
 			}
 		}
 
@@ -1127,7 +1126,7 @@ func validateNsConfUpdate(
 
 	err := validateStorageEngineDeviceList(&oldConf, &newConf)
 	if err != nil {
-		return fmt.Errorf("%v", err)
+		return err
 	}
 
 	// Check for namespace name len

--- a/api/v1beta1/aerospikecluster_validating_webhook.go
+++ b/api/v1beta1/aerospikecluster_validating_webhook.go
@@ -1037,6 +1037,8 @@ func validateNsConfUpdate(
 
 	newNsConfList := newConf["namespaces"].([]interface{})
 
+	// deviceList stores used devices in existing namespaces.
+	// Its key is the device and its value is the namespace where the device is used. 
 	deviceList := map[string]string{}
 
 	for _, singleConfInterface := range newNsConfList {
@@ -1063,6 +1065,7 @@ func validateNsConfUpdate(
 			}
 
 			// Add oldSingleConf ns device list into deviceList if not already present
+			// Keep track of devices referenced in existing namespaces.
 			oldConfStorage := oldSingleConf["storage-engine"].(map[string]interface{})
 			oldConfDevices := oldConfStorage["devices"].([]string)
 			for _, device := range oldConfDevices {
@@ -1132,6 +1135,8 @@ func validateNsConfUpdate(
 						newDevice, namespace,
 					)
 				}
+				// The device of the new namespace does not exists in the deviceList.
+				// We add entry for the new device to keep track of the devices (Use case: addition of multiple ns)
 				deviceList[newDevice] = singleConf["name"].(string)
 			}
 		}

--- a/api/v1beta1/aerospikecluster_validating_webhook_test.go
+++ b/api/v1beta1/aerospikecluster_validating_webhook_test.go
@@ -1,0 +1,187 @@
+package v1beta1
+
+import (
+	"testing"
+	"fmt"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var colorGreen = "\033[32m"
+var colorRed = "\033[31m"
+var colorReset = "\033[0m"
+
+// To test: go to /api/v1beta1 and run this command:
+// go test -run TestEnhancePesistentNamespaces
+func TestEnhancePesistentNamespaces(t *testing.T) {
+	TestAddPesistentNamespaceWithNotUsedDevices(t)
+	TestAddPesistentNamespaceWithAlreadyUsedDevices(t)
+	TestAddMultiplePesistentNamespacesWithNotUsedDevices(t)
+	TestAddMultiplePesistentNamespacesWithAlreadyUsedDevices(t)
+}
+
+func TestAddPesistentNamespaceWithNotUsedDevices(t *testing.T) {
+	oldNsConf := map[string][]string {
+		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+	}
+	newNsConf := map[string][]string {
+		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace": []string{"/opt/data02/xvd01", "/opt/data02/xvd02"},
+	}
+
+	aslog := logf.Log.WithName("Test validateNsConfUpdate")
+	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
+
+	err := validateNsConfUpdate(aslog, &newNamespaceConfig, &oldNamespaceConfig)
+	if err != nil {
+		fmt.Println(string(colorRed), "TestAddPesistentNamespaceWithNotUsedDevices failed.", string(colorReset))
+		t.Fatalf("Got error while creating persistent namespace: %v", err)
+	} else {
+		fmt.Println(string(colorGreen), "TestAddPesistentNamespaceWithNotUsedDevices passed!", string(colorReset))
+	}
+}
+
+// validateNsConfUpdate should return an error because we are using an already used device
+func TestAddPesistentNamespaceWithAlreadyUsedDevices(t *testing.T) {
+	oldNsConf := map[string][]string {
+		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+	}
+	newNsConf := map[string][]string {
+		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace": []string{"/opt/data01/xvd01", "/opt/data02/xvd02"}, // <- Using same device "/opt/data01/xvd01" as namespace-0
+	}
+
+	aslog := logf.Log.WithName("Test validateNsConfUpdate")
+	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
+
+	err := validateNsConfUpdate(aslog, &newNamespaceConfig, &oldNamespaceConfig)
+	if err == nil {
+		fmt.Println(string(colorRed), "TestAddPesistentNamespaceWithAlreadyUsedDevices failed.", string(colorReset))
+		t.Fatalf("Got error while creating persistent namespace: %v", err)
+	} else {
+		fmt.Println(string(colorGreen), "TestAddPesistentNamespaceWithAlreadyUsedDevices passed!", string(colorReset))
+	}
+}
+
+func TestAddMultiplePesistentNamespacesWithNotUsedDevices(t *testing.T) {
+	oldNsConf := map[string][]string {
+		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+	}
+	newNsConf := map[string][]string {
+		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace-0": []string{"/opt/data02/xvd01", "/opt/data02/xvd02"},
+		"new-namespace-1": []string{"/opt/data02/xvd03", "/opt/data02/xvd04"},
+	}
+
+	aslog := logf.Log.WithName("Test validateNsConfUpdate")
+	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
+
+	err := validateNsConfUpdate(aslog, &newNamespaceConfig, &oldNamespaceConfig)
+	if err != nil {
+		fmt.Println(string(colorRed), "TestAddMultiplePesistentNamespacesWithNotUsedDevices failed.", string(colorReset))
+		t.Fatalf("Got error while creating persistent namespace: %v", err)
+	} else {
+		fmt.Println(string(colorGreen), "TestAddMultiplePesistentNamespacesWithNotUsedDevices passed!", string(colorReset))
+	}
+}
+
+// validateNsConfUpdate should return an error because we are using an already used device
+func TestAddMultiplePesistentNamespacesWithAlreadyUsedDevices(t *testing.T) {
+	oldNsConf := map[string][]string {
+		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+	}
+	newNsConf := map[string][]string {
+		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace-0": []string{"/opt/data02/xvd01", "/opt/data02/xvd02"},
+		"new-namespace-1": []string{"/opt/data02/xvd01", "/opt/data02/xvd04"}, // <- Using same device "/opt/data02/xvd01" as new-namespace-0
+	}
+
+	aslog := logf.Log.WithName("Test validateNsConfUpdate")
+	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
+
+	err := validateNsConfUpdate(aslog, &newNamespaceConfig, &oldNamespaceConfig)
+	if err == nil {
+		fmt.Println(string(colorRed), "TestAddMultiplePesistentNamespacesWithAlreadyUsedDevices failed.", string(colorReset))
+		t.Fatalf("Got error while creating persistent namespace: %v", err)
+	} else {
+		fmt.Println(string(colorGreen), "TestAddMultiplePesistentNamespacesWithAlreadyUsedDevices passed!", string(colorReset))
+	}
+}
+
+//******************************************************************************
+// 									Helper
+//******************************************************************************
+
+func buildEmptyNsConf() AerospikeConfigSpec {
+	emptyConf := AerospikeConfigSpec{
+		Value: map[string]interface{}{
+			"namespaces":              []interface{}{},
+			"tls-name":                "test-tls",
+			"replication-factor":      2,
+			"tls-authenticate-client": "test-auth-tls",
+		},
+	}
+	return emptyConf
+}
+
+func addDeviceToPersistentNamesapce(namespace string, device string, conf *AerospikeConfigSpec) {
+	config := conf.Value
+	nsConfList := config["namespaces"].([]interface{})
+
+	exists, index := namespaceAlreadyExists(nsConfList, namespace)
+
+	if !exists {
+		newNamespace := map[string]interface{}{
+			"name": namespace,
+			"storage-engine": map[string]interface{}{
+				"type":    "device",
+				"devices": []string{device},
+			},
+		}
+		nsConfList = append(nsConfList, newNamespace)
+	} else {
+		nsConf := nsConfList[index].(map[string]interface{})
+		storage := nsConf["storage-engine"].(map[string]interface{})
+		devices := storage["devices"].([]string)
+		devices = append(devices, device)
+		storage["devices"] = devices
+		nsConf["storage-engine"] = storage
+		nsConfList[index] = nsConf
+	}
+
+	conf.Value["namespaces"] = nsConfList
+}
+
+func namespaceAlreadyExists(nsConfList []interface{}, namespace string) (bool, int) {
+	if len(nsConfList) == 0 {
+		return false, -1
+	}
+
+	for index, nsConfInterface := range nsConfList {
+		ncConf := nsConfInterface.(map[string]interface{})
+		if namespace == ncConf["name"] {
+			return true, index
+		}
+	}
+
+	return false, -1
+}
+
+func prepareNsConfigurations(oldNamespaceConf map[string][]string, newNamespaceConf map[string][]string) (AerospikeConfigSpec, AerospikeConfigSpec) {
+	oldNamespaceConfig := buildEmptyNsConf()
+	newNamespaceConfig := buildEmptyNsConf()
+
+	for namespace, deviceList := range oldNamespaceConf {
+		for _, device := range deviceList{
+			addDeviceToPersistentNamesapce(namespace, device, &oldNamespaceConfig)
+		}
+	}
+
+	for namespace, deviceList := range newNamespaceConf {
+		for _, device := range deviceList{
+			addDeviceToPersistentNamesapce(namespace, device, &newNamespaceConfig)
+		}
+	}
+
+	return oldNamespaceConfig, newNamespaceConfig
+}

--- a/api/v1beta1/aerospikecluster_validating_webhook_test.go
+++ b/api/v1beta1/aerospikecluster_validating_webhook_test.go
@@ -2,109 +2,279 @@ package v1beta1
 
 import (
 	"testing"
-	"fmt"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var colorGreen = "\033[32m"
-var colorRed = "\033[31m"
-var colorReset = "\033[0m"
+var aslog = logf.Log.WithName("Test validateNsConfUpdate")
 
-// To test: go to /api/v1beta1 and run this command:
-// go test -run TestEnhancePesistentNamespaces
-func TestEnhancePesistentNamespaces(t *testing.T) {
-	TestAddPesistentNamespaceWithNotUsedDevices(t)
-	TestAddPesistentNamespaceWithAlreadyUsedDevices(t)
-	TestAddMultiplePesistentNamespacesWithNotUsedDevices(t)
-	TestAddMultiplePesistentNamespacesWithAlreadyUsedDevices(t)
-}
-
+// validateNsConfUpdate should return nil because we are adding a new namespace with unused devices
 func TestAddPesistentNamespaceWithNotUsedDevices(t *testing.T) {
-	oldNsConf := map[string][]string {
-		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+	oldNsConf := map[string][]string{
+		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
 	}
-	newNsConf := map[string][]string {
-		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
-		"new-namespace": []string{"/opt/data02/xvd01", "/opt/data02/xvd02"},
+	newNsConf := map[string][]string{
+		"namespace-0":   {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
 	}
 
-	aslog := logf.Log.WithName("Test validateNsConfUpdate")
 	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
 
 	err := validateNsConfUpdate(aslog, &newNamespaceConfig, &oldNamespaceConfig)
 	if err != nil {
-		fmt.Println(string(colorRed), "TestAddPesistentNamespaceWithNotUsedDevices failed.", string(colorReset))
 		t.Fatalf("Got error while creating persistent namespace: %v", err)
-	} else {
-		fmt.Println(string(colorGreen), "TestAddPesistentNamespaceWithNotUsedDevices passed!", string(colorReset))
 	}
 }
 
 // validateNsConfUpdate should return an error because we are using an already used device
 func TestAddPesistentNamespaceWithAlreadyUsedDevices(t *testing.T) {
-	oldNsConf := map[string][]string {
-		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+	oldNsConf := map[string][]string{
+		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
 	}
-	newNsConf := map[string][]string {
-		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
-		"new-namespace": []string{"/opt/data01/xvd01", "/opt/data02/xvd02"}, // <- Using same device "/opt/data01/xvd01" as namespace-0
+	newNsConf := map[string][]string{
+		"namespace-0":   {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace": {"/opt/data01/xvd01", "/opt/data02/xvd02"}, // <- Using same device "/opt/data01/xvd01" as namespace-0
 	}
 
-	aslog := logf.Log.WithName("Test validateNsConfUpdate")
 	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
 
 	err := validateNsConfUpdate(aslog, &newNamespaceConfig, &oldNamespaceConfig)
 	if err == nil {
-		fmt.Println(string(colorRed), "TestAddPesistentNamespaceWithAlreadyUsedDevices failed.", string(colorReset))
 		t.Fatalf("Got error while creating persistent namespace: %v", err)
-	} else {
-		fmt.Println(string(colorGreen), "TestAddPesistentNamespaceWithAlreadyUsedDevices passed!", string(colorReset))
 	}
 }
 
+// validateNsConfUpdate should return nil because we are adding multiple namespaces with unused devices
 func TestAddMultiplePesistentNamespacesWithNotUsedDevices(t *testing.T) {
-	oldNsConf := map[string][]string {
-		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+	oldNsConf := map[string][]string{
+		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
 	}
-	newNsConf := map[string][]string {
-		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
-		"new-namespace-0": []string{"/opt/data02/xvd01", "/opt/data02/xvd02"},
-		"new-namespace-1": []string{"/opt/data02/xvd03", "/opt/data02/xvd04"},
+	newNsConf := map[string][]string{
+		"namespace-0":     {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
+		"new-namespace-1": {"/opt/data02/xvd03", "/opt/data02/xvd04"},
 	}
 
-	aslog := logf.Log.WithName("Test validateNsConfUpdate")
 	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
 
 	err := validateNsConfUpdate(aslog, &newNamespaceConfig, &oldNamespaceConfig)
 	if err != nil {
-		fmt.Println(string(colorRed), "TestAddMultiplePesistentNamespacesWithNotUsedDevices failed.", string(colorReset))
 		t.Fatalf("Got error while creating persistent namespace: %v", err)
-	} else {
-		fmt.Println(string(colorGreen), "TestAddMultiplePesistentNamespacesWithNotUsedDevices passed!", string(colorReset))
 	}
 }
 
-// validateNsConfUpdate should return an error because we are using an already used device
+// validateNsConfUpdate should return an error because we are adding multiple namespaces with already used devices
 func TestAddMultiplePesistentNamespacesWithAlreadyUsedDevices(t *testing.T) {
-	oldNsConf := map[string][]string {
-		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+	oldNsConf := map[string][]string{
+		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
 	}
-	newNsConf := map[string][]string {
-		"namespace-0": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
-		"new-namespace-0": []string{"/opt/data02/xvd01", "/opt/data02/xvd02"},
-		"new-namespace-1": []string{"/opt/data02/xvd01", "/opt/data02/xvd04"}, // <- Using same device "/opt/data02/xvd01" as new-namespace-0
+	newNsConf := map[string][]string{
+		"namespace-0":     {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
+		"new-namespace-1": {"/opt/data02/xvd01", "/opt/data02/xvd04"}, // <- Using same device "/opt/data02/xvd01" as new-namespace-0
 	}
 
-	aslog := logf.Log.WithName("Test validateNsConfUpdate")
 	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
 
 	err := validateNsConfUpdate(aslog, &newNamespaceConfig, &oldNamespaceConfig)
 	if err == nil {
-		fmt.Println(string(colorRed), "TestAddMultiplePesistentNamespacesWithAlreadyUsedDevices failed.", string(colorReset))
 		t.Fatalf("Got error while creating persistent namespace: %v", err)
-	} else {
-		fmt.Println(string(colorGreen), "TestAddMultiplePesistentNamespacesWithAlreadyUsedDevices passed!", string(colorReset))
+	}
+}
+
+// validateNsConfUpdate should return nil because we are adding unused devices to an existing namespace
+func TestAddDevicesToExistantNamespace(t *testing.T) {
+	oldNsConf := map[string][]string{
+		"namespace-0":     {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
+	}
+	newNsConf := map[string][]string{
+		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace-0": {
+			"/opt/data02/xvd01", "/opt/data02/xvd02",
+			"/opt/data02/xvd03", "/opt/data02/xvd04",
+		},
+	}
+
+	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
+
+	err := validateNsConfUpdate(aslog, &newNamespaceConfig, &oldNamespaceConfig)
+	if err != nil {
+		t.Fatalf("Got error while creating persistent namespace: %v", err)
+	}
+}
+
+// validateNsConfUpdate should return an error because we are adding used devices by another namespace to an existing namespace
+func TestAddUsedDeviceByAnotherNamespaceToExistantNamespace(t *testing.T) {
+	oldNsConf := map[string][]string{
+		"namespace-0":     {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
+	}
+	newNsConf := map[string][]string{
+		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace-0": {
+			"/opt/data02/xvd01", "/opt/data02/xvd02",
+			"/opt/data01/xvd01", "/opt/data02/xvd04", // <- Using same device "/opt/data01/xvd01" as namespace-0
+		},
+	}
+
+	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
+
+	err := validateNsConfUpdate(aslog, &newNamespaceConfig, &oldNamespaceConfig)
+	if err == nil {
+		t.Fatalf("Got error while creating persistent namespace: %v", err)
+	}
+}
+
+// validateNsConfUpdate should return an error because we are adding used devices by same namespace to an existing namespace
+func TestAddUsedDeviceBySameNamespaceToExistantNamespace(t *testing.T) {
+	oldNsConf := map[string][]string{
+		"namespace-0":     {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
+	}
+	newNsConf := map[string][]string{
+		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace-0": {
+			"/opt/data02/xvd01", "/opt/data02/xvd02",
+			"/opt/data02/xvd01", "/opt/data02/xvd04", // <- Using same device "/opt/data02/xvd01" as new-namespace-0
+		},
+	}
+
+	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
+
+	err := validateNsConfUpdate(aslog, &newNamespaceConfig, &oldNamespaceConfig)
+	if err == nil {
+		t.Fatalf("Got error while creating persistent namespace: %v", err)
+	}
+}
+
+// validateNsConfUpdate should return nil because we are adding unused devices to an existing namespace
+func TestAddDevicesToMultipleExistantNamespaces(t *testing.T) {
+	oldNsConf := map[string][]string{
+		"namespace-0":     {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
+		"new-namespace-1": {"/opt/data03/xvd01", "/opt/data03/xvd02"},
+	}
+	newNsConf := map[string][]string{
+		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace-0": {
+			"/opt/data02/xvd01", "/opt/data02/xvd02",
+			"/opt/data02/xvd03", "/opt/data02/xvd04",
+		},
+		"new-namespace-1": {
+			"/opt/data03/xvd01", "/opt/data03/xvd02",
+			"/opt/data03/xvd03", "/opt/data03/xvd04",
+		},
+	}
+
+	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
+
+	err := validateNsConfUpdate(aslog, &newNamespaceConfig, &oldNamespaceConfig)
+	if err != nil {
+		t.Fatalf("Got error while creating persistent namespace: %v", err)
+	}
+}
+
+// validateNsConfUpdate should return an error because we are adding used devices to an existing namespace
+func TestAddUsedDeviceToMultipleExistantNamespace(t *testing.T) {
+	oldNsConf := map[string][]string{
+		"namespace-0":     {},
+		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
+		"new-namespace-1": {"/opt/data03/xvd01", "/opt/data03/xvd02"},
+	}
+	newNsConf := map[string][]string{
+		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"new-namespace-0": {
+			"/opt/data02/xvd01", "/opt/data02/xvd02",
+			"/opt/data02/xvd03", "/opt/data01/xvd01",
+		},
+		"new-namespace-1": {
+			"/opt/data03/xvd01", "/opt/data03/xvd02",
+			"/opt/data02/xvd03", "/opt/data03/xvd04", // <- Using same device "/opt/data02/xvd03" as new-namespace-0
+		},
+	}
+
+	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
+
+	err := validateNsConfUpdate(aslog, &newNamespaceConfig, &oldNamespaceConfig)
+	if err == nil {
+		t.Fatalf("Got error while creating persistent namespace: %v", err)
+	}
+}
+
+// validateStorageConfiguration should return nil because we are adding unused devices and keeping the same type.
+func TestValidateStorageConfiguration(t *testing.T) {
+	oldStorage := map[string]interface{}{
+		"type":    "device",
+		"devices": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+	}
+	newStorage := map[string]interface{}{
+		"type": "device",
+		"devices": []string{
+			"/opt/data01/xvd01", "/opt/data01/xvd02",
+			"/opt/data01/xvd03", "/opt/data01/xvd04",
+		},
+	}
+
+	err := validateStorageConfiguration(oldStorage, newStorage, "test-namespace")
+	if err != nil {
+		t.Fatalf("Got error while validating storage configuration: %v", err)
+	}
+}
+
+// validateStorageConfiguration should return an error because we are changing the type of the storage.
+func TestValidateStorageConfigurationByChangingStorageType(t *testing.T) {
+	oldStorage := map[string]interface{}{
+		"type":    "device",
+		"devices": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+	}
+	newStorage := map[string]interface{}{
+		"type":    "memory",
+		"devices": []string{},
+	}
+
+	err := validateStorageConfiguration(oldStorage, newStorage, "test-namespace")
+	if err == nil {
+		t.Fatalf("Got error while validating storage configuration: %v", err)
+	}
+}
+
+// validateStorageConfiguration should return an error because we are using a same device.
+func TestValidateStorageConfigurationByUsingUsedDevice(t *testing.T) {
+	oldStorage := map[string]interface{}{
+		"type":    "device",
+		"devices": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+	}
+	newStorage := map[string]interface{}{
+		"type": "device",
+		"devices": []string{
+			"/opt/data01/xvd01", "/opt/data01/xvd02",
+			"/opt/data01/xvd01", "/opt/data01/xvd03", // <- Using same device "/opt/data01/xvd01" twice
+		},
+	}
+
+	err := validateStorageConfiguration(oldStorage, newStorage, "test-namespace")
+	if err == nil {
+		t.Fatalf("Got error while validating storage configuration: %v", err)
+	}
+}
+
+// validateStorageConfiguration should return an error because we are deleting a device.
+func TestValidateStorageConfigurationByDeletingDevice(t *testing.T) {
+	oldStorage := map[string]interface{}{
+		"type":    "device",
+		"devices": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+	}
+	newStorage := map[string]interface{}{
+		"type": "device",
+		"devices": []string{
+			"/opt/data01/xvd02", "/opt/data01/xvd03", "/opt/data01/xvd04", // <- Deleting device "/opt/data01/xvd01"
+		},
+	}
+
+	err := validateStorageConfiguration(oldStorage, newStorage, "test-namespace")
+	if err == nil {
+		t.Fatalf("Got error while validating storage configuration: %v", err)
 	}
 }
 
@@ -172,13 +342,13 @@ func prepareNsConfigurations(oldNamespaceConf map[string][]string, newNamespaceC
 	newNamespaceConfig := buildEmptyNsConf()
 
 	for namespace, deviceList := range oldNamespaceConf {
-		for _, device := range deviceList{
+		for _, device := range deviceList {
 			addDeviceToPersistentNamesapce(namespace, device, &oldNamespaceConfig)
 		}
 	}
 
 	for namespace, deviceList := range newNamespaceConf {
-		for _, device := range deviceList{
+		for _, device := range deviceList {
 			addDeviceToPersistentNamesapce(namespace, device, &newNamespaceConfig)
 		}
 	}

--- a/api/v1beta1/aerospikecluster_validating_webhook_test.go
+++ b/api/v1beta1/aerospikecluster_validating_webhook_test.go
@@ -11,11 +11,11 @@ var aslog = logf.Log.WithName("Test validateNsConfUpdate")
 // validateNsConfUpdate should return nil because we are adding a new namespace with unused devices
 func TestAddPesistentNamespaceWithNotUsedDevices(t *testing.T) {
 	oldNsConf := map[string][]string{
-		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"namespace-0": {"/dev/nvme1", "/dev/nvme2"},
 	}
 	newNsConf := map[string][]string{
-		"namespace-0":   {"/opt/data01/xvd01", "/opt/data01/xvd02"},
-		"new-namespace": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
+		"namespace-0":   {"/dev/nvme1", "/dev/nvme2"},
+		"new-namespace": {"/dev/nvme3", "/dev/nvme4"},
 	}
 
 	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
@@ -29,11 +29,11 @@ func TestAddPesistentNamespaceWithNotUsedDevices(t *testing.T) {
 // validateNsConfUpdate should return an error because we are using an already used device
 func TestAddPesistentNamespaceWithAlreadyUsedDevices(t *testing.T) {
 	oldNsConf := map[string][]string{
-		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"namespace-0": {"/dev/nvme1", "/dev/nvme2"},
 	}
 	newNsConf := map[string][]string{
-		"namespace-0":   {"/opt/data01/xvd01", "/opt/data01/xvd02"},
-		"new-namespace": {"/opt/data01/xvd01", "/opt/data02/xvd02"}, // <- Using same device "/opt/data01/xvd01" as namespace-0
+		"namespace-0":   {"/dev/nvme1", "/dev/nvme2"},
+		"new-namespace": {"/dev/nvme1", "/dev/nvme4"}, // <- Using same device "/dev/nvme1" as namespace-0
 	}
 
 	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
@@ -47,12 +47,12 @@ func TestAddPesistentNamespaceWithAlreadyUsedDevices(t *testing.T) {
 // validateNsConfUpdate should return nil because we are adding multiple namespaces with unused devices
 func TestAddMultiplePesistentNamespacesWithNotUsedDevices(t *testing.T) {
 	oldNsConf := map[string][]string{
-		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"namespace-0": {"/dev/nvme1", "/dev/nvme2"},
 	}
 	newNsConf := map[string][]string{
-		"namespace-0":     {"/opt/data01/xvd01", "/opt/data01/xvd02"},
-		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
-		"new-namespace-1": {"/opt/data02/xvd03", "/opt/data02/xvd04"},
+		"namespace-0":     {"/dev/nvme1", "/dev/nvme2"},
+		"new-namespace-0": {"/dev/nvme3", "/dev/nvme4"},
+		"new-namespace-1": {"/dev/nvme5", "/dev/nvme6"},
 	}
 
 	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
@@ -66,12 +66,12 @@ func TestAddMultiplePesistentNamespacesWithNotUsedDevices(t *testing.T) {
 // validateNsConfUpdate should return an error because we are adding multiple namespaces with already used devices
 func TestAddMultiplePesistentNamespacesWithAlreadyUsedDevices(t *testing.T) {
 	oldNsConf := map[string][]string{
-		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"namespace-0": {"/dev/nvme1", "/dev/nvme2"},
 	}
 	newNsConf := map[string][]string{
-		"namespace-0":     {"/opt/data01/xvd01", "/opt/data01/xvd02"},
-		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
-		"new-namespace-1": {"/opt/data02/xvd01", "/opt/data02/xvd04"}, // <- Using same device "/opt/data02/xvd01" as new-namespace-0
+		"namespace-0":     {"/dev/nvme1", "/dev/nvme2"},
+		"new-namespace-0": {"/dev/nvme3", "/dev/nvme4"},
+		"new-namespace-1": {"/dev/nvme3", "/dev/nvme6"}, // <- Using same device "/dev/nvme3" as new-namespace-0
 	}
 
 	oldNamespaceConfig, newNamespaceConfig := prepareNsConfigurations(oldNsConf, newNsConf)
@@ -85,14 +85,14 @@ func TestAddMultiplePesistentNamespacesWithAlreadyUsedDevices(t *testing.T) {
 // validateNsConfUpdate should return nil because we are adding unused devices to an existing namespace
 func TestAddDevicesToExistantNamespace(t *testing.T) {
 	oldNsConf := map[string][]string{
-		"namespace-0":     {"/opt/data01/xvd01", "/opt/data01/xvd02"},
-		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
+		"namespace-0":     {"/dev/nvme1", "/dev/nvme2"},
+		"new-namespace-0": {"/dev/nvme3", "/dev/nvme4"},
 	}
 	newNsConf := map[string][]string{
-		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"namespace-0": {"/dev/nvme1", "/dev/nvme2"},
 		"new-namespace-0": {
-			"/opt/data02/xvd01", "/opt/data02/xvd02",
-			"/opt/data02/xvd03", "/opt/data02/xvd04",
+			"/dev/nvme3", "/dev/nvme4",
+			"/dev/nvme5", "/dev/nvme6",
 		},
 	}
 
@@ -107,14 +107,14 @@ func TestAddDevicesToExistantNamespace(t *testing.T) {
 // validateNsConfUpdate should return an error because we are adding used devices by another namespace to an existing namespace
 func TestAddUsedDeviceByAnotherNamespaceToExistantNamespace(t *testing.T) {
 	oldNsConf := map[string][]string{
-		"namespace-0":     {"/opt/data01/xvd01", "/opt/data01/xvd02"},
-		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
+		"namespace-0":     {"/dev/nvme1", "/dev/nvme2"},
+		"new-namespace-0": {"/dev/nvme3", "/dev/nvme4"},
 	}
 	newNsConf := map[string][]string{
-		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"namespace-0": {"/dev/nvme1", "/dev/nvme2"},
 		"new-namespace-0": {
-			"/opt/data02/xvd01", "/opt/data02/xvd02",
-			"/opt/data01/xvd01", "/opt/data02/xvd04", // <- Using same device "/opt/data01/xvd01" as namespace-0
+			"/dev/nvme3", "/dev/nvme4",
+			"/dev/nvme1", "/dev/nvme6", // <- Using same device "/dev/nvme1" as namespace-0
 		},
 	}
 
@@ -129,14 +129,14 @@ func TestAddUsedDeviceByAnotherNamespaceToExistantNamespace(t *testing.T) {
 // validateNsConfUpdate should return an error because we are adding used devices by same namespace to an existing namespace
 func TestAddUsedDeviceBySameNamespaceToExistantNamespace(t *testing.T) {
 	oldNsConf := map[string][]string{
-		"namespace-0":     {"/opt/data01/xvd01", "/opt/data01/xvd02"},
-		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
+		"namespace-0":     {"/dev/nvme1", "/dev/nvme2"},
+		"new-namespace-0": {"/dev/nvme3", "/dev/nvme4"},
 	}
 	newNsConf := map[string][]string{
-		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"namespace-0": {"/dev/nvme1", "/dev/nvme2"},
 		"new-namespace-0": {
-			"/opt/data02/xvd01", "/opt/data02/xvd02",
-			"/opt/data02/xvd01", "/opt/data02/xvd04", // <- Using same device "/opt/data02/xvd01" as new-namespace-0
+			"/dev/nvme3", "/dev/nvme4",
+			"/dev/nvme3", "/dev/nvme6", // <- Using same device "/dev/nvme3" as new-namespace-0
 		},
 	}
 
@@ -151,19 +151,19 @@ func TestAddUsedDeviceBySameNamespaceToExistantNamespace(t *testing.T) {
 // validateNsConfUpdate should return nil because we are adding unused devices to an existing namespace
 func TestAddDevicesToMultipleExistantNamespaces(t *testing.T) {
 	oldNsConf := map[string][]string{
-		"namespace-0":     {"/opt/data01/xvd01", "/opt/data01/xvd02"},
-		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
-		"new-namespace-1": {"/opt/data03/xvd01", "/opt/data03/xvd02"},
+		"namespace-0":     {"/dev/nvme1", "/dev/nvme2"},
+		"new-namespace-0": {"/dev/nvme3", "/dev/nvme4"},
+		"new-namespace-1": {"/dev/nvme7", "/dev/nvme8"},
 	}
 	newNsConf := map[string][]string{
-		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"namespace-0": {"/dev/nvme1", "/dev/nvme2"},
 		"new-namespace-0": {
-			"/opt/data02/xvd01", "/opt/data02/xvd02",
-			"/opt/data02/xvd03", "/opt/data02/xvd04",
+			"/dev/nvme3", "/dev/nvme4",
+			"/dev/nvme5", "/dev/nvme6",
 		},
 		"new-namespace-1": {
-			"/opt/data03/xvd01", "/opt/data03/xvd02",
-			"/opt/data03/xvd03", "/opt/data03/xvd04",
+			"/dev/nvme7", "/dev/nvme8",
+			"/dev/nvme9", "/dev/nvme10",
 		},
 	}
 
@@ -179,18 +179,18 @@ func TestAddDevicesToMultipleExistantNamespaces(t *testing.T) {
 func TestAddUsedDeviceToMultipleExistantNamespace(t *testing.T) {
 	oldNsConf := map[string][]string{
 		"namespace-0":     {},
-		"new-namespace-0": {"/opt/data02/xvd01", "/opt/data02/xvd02"},
-		"new-namespace-1": {"/opt/data03/xvd01", "/opt/data03/xvd02"},
+		"new-namespace-0": {"/dev/nvme3", "/dev/nvme4"},
+		"new-namespace-1": {"/dev/nvme7", "/dev/nvme8"},
 	}
 	newNsConf := map[string][]string{
-		"namespace-0": {"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"namespace-0": {"/dev/nvme1", "/dev/nvme2"},
 		"new-namespace-0": {
-			"/opt/data02/xvd01", "/opt/data02/xvd02",
-			"/opt/data02/xvd03", "/opt/data01/xvd01",
+			"/dev/nvme3", "/dev/nvme4",
+			"/dev/nvme5", "/dev/nvme6",
 		},
 		"new-namespace-1": {
-			"/opt/data03/xvd01", "/opt/data03/xvd02",
-			"/opt/data02/xvd03", "/opt/data03/xvd04", // <- Using same device "/opt/data02/xvd03" as new-namespace-0
+			"/dev/nvme7", "/dev/nvme8",
+			"/dev/nvme5", "/dev/nvme10", // <- Using same device "/dev/nvme5" as new-namespace-0
 		},
 	}
 
@@ -203,76 +203,76 @@ func TestAddUsedDeviceToMultipleExistantNamespace(t *testing.T) {
 }
 
 // validateStorageConfiguration should return nil because we are adding unused devices and keeping the same type.
-func TestValidateStorageConfiguration(t *testing.T) {
+func TestValidateStorageEngineConfiguration(t *testing.T) {
 	oldStorage := map[string]interface{}{
 		"type":    "device",
-		"devices": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"devices": []string{"/dev/nvme1", "/dev/nvme2"},
 	}
 	newStorage := map[string]interface{}{
 		"type": "device",
 		"devices": []string{
-			"/opt/data01/xvd01", "/opt/data01/xvd02",
-			"/opt/data01/xvd03", "/opt/data01/xvd04",
+			"/dev/nvme1", "/dev/nvme2",
+			"/dev/nvme3", "/dev/nvme4",
 		},
 	}
 
-	err := validateStorageConfiguration(oldStorage, newStorage, "test-namespace")
+	err := validateStorageEngineConfiguration(oldStorage, newStorage, "test-namespace")
 	if err != nil {
 		t.Fatalf("Got error while validating storage configuration: %v", err)
 	}
 }
 
 // validateStorageConfiguration should return an error because we are changing the type of the storage.
-func TestValidateStorageConfigurationByChangingStorageType(t *testing.T) {
+func TestValidateStorageEngineConfigurationByChangingStorageType(t *testing.T) {
 	oldStorage := map[string]interface{}{
 		"type":    "device",
-		"devices": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"devices": []string{"/dev/nvme1", "/dev/nvme2"},
 	}
 	newStorage := map[string]interface{}{
 		"type":    "memory",
 		"devices": []string{},
 	}
 
-	err := validateStorageConfiguration(oldStorage, newStorage, "test-namespace")
+	err := validateStorageEngineConfiguration(oldStorage, newStorage, "test-namespace")
 	if err == nil {
 		t.Fatalf("Got error while validating storage configuration: %v", err)
 	}
 }
 
 // validateStorageConfiguration should return an error because we are using a same device.
-func TestValidateStorageConfigurationByUsingUsedDevice(t *testing.T) {
+func TestValidateStorageEngineConfigurationByUsingUsedDevice(t *testing.T) {
 	oldStorage := map[string]interface{}{
 		"type":    "device",
-		"devices": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"devices": []string{"/dev/nvme1", "/dev/nvme2"},
 	}
 	newStorage := map[string]interface{}{
 		"type": "device",
 		"devices": []string{
-			"/opt/data01/xvd01", "/opt/data01/xvd02",
-			"/opt/data01/xvd01", "/opt/data01/xvd03", // <- Using same device "/opt/data01/xvd01" twice
+			"/dev/nvme1", "/dev/nvme2",
+			"/dev/nvme1", "/dev/nvme3", // <- Using same device "/dev/nvme1" twice
 		},
 	}
 
-	err := validateStorageConfiguration(oldStorage, newStorage, "test-namespace")
+	err := validateStorageEngineConfiguration(oldStorage, newStorage, "test-namespace")
 	if err == nil {
 		t.Fatalf("Got error while validating storage configuration: %v", err)
 	}
 }
 
 // validateStorageConfiguration should return an error because we are deleting a device.
-func TestValidateStorageConfigurationByDeletingDevice(t *testing.T) {
+func TestValidateStorageEngineConfigurationByDeletingDevice(t *testing.T) {
 	oldStorage := map[string]interface{}{
 		"type":    "device",
-		"devices": []string{"/opt/data01/xvd01", "/opt/data01/xvd02"},
+		"devices": []string{"/dev/nvme1", "/dev/nvme2"},
 	}
 	newStorage := map[string]interface{}{
 		"type": "device",
 		"devices": []string{
-			"/opt/data01/xvd02", "/opt/data01/xvd03", "/opt/data01/xvd04", // <- Deleting device "/opt/data01/xvd01"
+			"/dev/nvme2", "/dev/nvme3", "/dev/nvme4", // <- Deleting device "/dev/nvme1"
 		},
 	}
 
-	err := validateStorageConfiguration(oldStorage, newStorage, "test-namespace")
+	err := validateStorageEngineConfiguration(oldStorage, newStorage, "test-namespace")
 	if err == nil {
 		t.Fatalf("Got error while validating storage configuration: %v", err)
 	}


### PR DESCRIPTION
Documentation:
https://criteo.atlassian.net/wiki/spaces/STORAGE/pages/1681168392/Enhancing+namespace+management+capacity+of+Aerospike+Kubernetes+Operator.