### PR TITLE
Fix unit tests execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ IMG ?= controller:latest
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false,maxDescLen=70"
 
 # # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-# ENVTEST_K8S_VERSION = 1.21
+ENVTEST_K8S_VERSION = 1.16
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -101,7 +101,7 @@ vet: ## Run go vet against code.
 
 test: manifests generate fmt vet envtest ## Run tests.
 	# KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" cd $(shell pwd)/test; go test ${TEST_ARGS}  -ginkgo.v -ginkgo.progress -timeout=600m -coverprofile cover.out
+	cd $(shell pwd)/test; KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ${TEST_ARGS}  -ginkgo.v -ginkgo.progress -timeout=600m -coverprofile cover.out
 
 ##@ Build
 


### PR DESCRIPTION
make test was failing to start local kube env due to
KUBEBUILDER_ASSETS environment variable not properly
set during execution of go test.

Also set minimum kubernetes cluster version 1.16