### PR TITLE
fix ldap query escaping

### DIFF
--- a/api/v1beta1/aerospikecluster_mutating_webhook.go
+++ b/api/v1beta1/aerospikecluster_mutating_webhook.go
@@ -772,8 +772,8 @@ func escapeValue(valueGeneric interface{}) interface{} {
 }
 
 func escapeString(str string) string {
-	str = strings.ReplaceAll(str, "${un}", "$${_DNE}{un}")
-	str = strings.ReplaceAll(str, "${dn}", "$${_DNE}{dn}")
+	str = strings.ReplaceAll(str, "${un}", "\\${un}")
+	str = strings.ReplaceAll(str, "${dn}", "\\${dn}")
 
 	return str
 }

--- a/api/v1beta1/aerospikecluster_mutating_webhook_test.go
+++ b/api/v1beta1/aerospikecluster_mutating_webhook_test.go
@@ -1,0 +1,48 @@
+package v1beta1
+
+import "testing"
+
+func TestLdapQueryEscaping(t *testing.T) {
+	ldapConf := map[string]string{
+		"disable-tls":              "false",
+		"login-threads":            "64",
+		"query-base-dn":            "DC=uad,DC=preprod,DC=example,DC=org",
+		"query-user-dn":            "CN=serviceaccount,OU=ou,DC=dc,DC=preprod,DC=example,DC=org",
+		"query-user-password-file": "/etc/aerospike/secret/ldap_password.txt",
+		"role-query-pattern":       "(&(objectClass=group)(member=${dn}))",
+		"server":                   "ldap://uad.preprod.example.org",
+		"tls-ca-file":              "/etc/aerospike/secret/ldap_ca.crt",
+		"user-query-pattern":       "(cn=${un})",
+	}
+	securityConf := map[string]interface{}{
+		"ldap": ldapConf,
+	}
+	config := AerospikeConfigSpec{}
+	config.Value = map[string]interface{}{
+		"security": securityConf,
+	}
+
+	escapeLDAPConfiguration(config)
+	if _, ok := config.Value["security"]; ok {
+		securityConf := config.Value["security"].(map[string]interface{})
+		if _, ok := securityConf["ldap"]; ok {
+			ldapConf := securityConf["ldap"].(map[string]string)
+
+			roleQueryPattern := ldapConf["role-query-pattern"]
+			expectedRoleQueryPattern := "(&(objectClass=group)(member=\\${dn}))"
+			if roleQueryPattern != expectedRoleQueryPattern {
+				t.Errorf("role-query-pattern unproperly escaped, get %s, expected %s", roleQueryPattern, expectedRoleQueryPattern)
+			}
+
+			userQueryPattern := ldapConf["user-query-pattern"]
+			expectedUserQueryPattern := "(cn=\\${un})"
+			if userQueryPattern != expectedUserQueryPattern {
+				t.Errorf("role-query-pattern unproperly escaped, get %s, expected %s", userQueryPattern, expectedUserQueryPattern)
+			}
+		} else {
+			t.Error("ldap section lost")
+		}
+	} else {
+		t.Error("security section lost")
+	}
+}


### PR DESCRIPTION
Between 5.7.0.24 and 5.7.0.25, aerospike changed templating of /etc/aerospike/aerospike.conf:
* In 5.7.0.24 templating was powered by envsubst (from gettext package)
* In 5.7.0.25 templating is implemented by a custom bash function

https://github.com/aerospike/aerospike-server.docker/commit/1d629687a35e89bc0d9400badd620fb66bda38e2

The new function isn’t strictly equivalent to envsubst. The line “update=$(eval echo "\"${line}\"")" does more than environment variable substitution, it also support bash special variables expansion.

So when we pass (cn=$${_DNE}{un}) or (cn=$${escape}{un})
* envsubst was replacing ${_DNE} or ${escape} by an empty string, producing (cn=${un})
* the new function replaces $$ by current pid, producing (cn=6{_DNE}{un}) or (cn=6{escape}{un}). Breaking ldap configuration

We amend mutating webhook to escape $ by \$