### PR TITLE
Add custom label to aerospike cluster cr via helm chart

### DIFF
--- a/helm-charts/aerospike-cluster/templates/aerospike-cluster-cr.yaml
+++ b/helm-charts/aerospike-cluster/templates/aerospike-cluster-cr.yaml
@@ -7,6 +7,10 @@ metadata:
     app: {{ template "aerospike-cluster.commonName" . }}
     chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
+    {{- with .Values.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 spec:
   # Aerospike cluster size
   size: {{ .Values.replicas | default 3 }}

--- a/helm-charts/aerospike-cluster/values.yaml
+++ b/helm-charts/aerospike-cluster/values.yaml
@@ -8,7 +8,20 @@ replicas: 3
 ## Aerospike server docker image
 image:
   repository: aerospike/aerospike-server-enterprise
+<<<<<<< HEAD
   tag: 6.3.0.0
+=======
+  tag: 5.7.0.8
+
+## Custom labels that will be applied on the aerospikecluster resource
+customLabels: {}
+
+## Init image
+initImage:
+  repository: aerospike/aerospike-kubernetes-init
+  tag: 0.0.15
+  # pullPolicy: IfNotPresent
+>>>>>>> e10c6ad (Add custom label to aerospike cluster cr via helm chart)
 
 ## In case the above image is pulled from a registry that requires
 ## authentication, a secret containining credentials can be added


### PR DESCRIPTION
This change makes possible the addition of custom labels to the aerospike cluster custom ressource at deployement time using Helm