### PR TITLE
Fix custom label to aerospike cluster cr via helm chart

### DIFF
--- a/helm-charts/aerospike-cluster/values.yaml
+++ b/helm-charts/aerospike-cluster/values.yaml
@@ -8,20 +8,10 @@ replicas: 3
 ## Aerospike server docker image
 image:
   repository: aerospike/aerospike-server-enterprise
-<<<<<<< HEAD
   tag: 6.3.0.0
-=======
-  tag: 5.7.0.8
 
 ## Custom labels that will be applied on the aerospikecluster resource
 customLabels: {}
-
-## Init image
-initImage:
-  repository: aerospike/aerospike-kubernetes-init
-  tag: 0.0.15
-  # pullPolicy: IfNotPresent
->>>>>>> e10c6ad (Add custom label to aerospike cluster cr via helm chart)
 
 ## In case the above image is pulled from a registry that requires
 ## authentication, a secret containining credentials can be added


### PR DESCRIPTION
This change fixes the possible addition of custom labels to the aerospike cluster custom ressource at deployement time using Helm