### PR TITLE
Backport readiness probe code from upstream

### DIFF
--- a/controllers/pod.go
+++ b/controllers/pod.go
@@ -142,6 +142,13 @@ func (r *SingleClusterReconciler) getRollingRestartTypePod(
 		r.Log.Info("Aerospike rack storage changed. Need rolling restart")
 	}
 
+	if r.isReadinessProbeUpdated(pod) {
+		restartType = mergeRestartType(restartType, podRestart)
+
+		r.Log.Info("Aerospike readiness tcp port changed. Need rolling restart",
+			"newTCPPort", r.getReadinessProbe().TCPSocket.String())
+	}
+
 	return restartType
 }
 


### PR DESCRIPTION
Backport from be63a71 (but cold-roll-restart the STS if the readiness probe is not yet installed).

Currently, the operator doesn't wait for a pod to be fully initialized and accepting connections when performing a rolling restart. Merging this change will cause roll-restart of all pods.

PDB code is not backported as we already have a PDB object managed externally (whereas upstream creates & manages one). It is not sufficient to replace some calls to "delete pod" by "evict pod", because this doesn't take hot-restart into account.