### PR TITLE
Use eviction instead of deletion when restarting active pods

### DIFF
--- a/helm-charts/aerospike-kubernetes-operator/templates/clusterrole_aerospike-operator-manager-role.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/clusterrole_aerospike-operator-manager-role.yaml
@@ -106,6 +106,7 @@ rules:
   - ""
   resources:
   - pods/exec
+  - pods/eviction
   verbs:
   - create
 - apiGroups:


### PR DESCRIPTION
This is a continuation of the previous commit introducing the readiness probe.

Note that this commits only affects cold restarts, not hot restarts