### PR TITLE
Backport and squash three commits about eviction management from criteo-2.5.0

### DIFF
--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-manager-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-manager-clusterrole.yaml
@@ -96,6 +96,7 @@ rules:
   - ""
   resources:
   - pods/exec
+  - pods/eviction
   verbs:
   - create
 - apiGroups:


### PR DESCRIPTION
Use eviction instead of deletion when restarting active pods

Note that this commits only affects cold restarts, not hot restarts

Improve Quiesce management when evicting pods
* Perform a DryRun eviction before Quiescing a node.
* QuiesceUndo when pod fail to evict.

Force a "recluster" by calling InfoQuiesce with an empty list of pods Explanation:
aerospike-lib-management performs a recluster during a QuiesceUndo. Unfortunately if we pass a subset of nodes to QuiesceUndo, the recluster cannot happen since it will be done using the list of host of the QuiesceUndo.