### PR TITLE
Add finalizer required to handle pvc deletion

### DIFF
--- a/helm-charts/aerospike-cluster/templates/aerospike-cluster-cr.yaml
+++ b/helm-charts/aerospike-cluster/templates/aerospike-cluster-cr.yaml
@@ -3,10 +3,15 @@ kind: AerospikeCluster
 metadata:
   name: {{ template "aerospike-cluster.commonName" . }}
   namespace: {{ .Release.Namespace }}
+  # finalizer needed to handle pvc deletion when AerospikeCluster is deleted.
+  finalizers:
+    - asdb.aerospike.com/storage-finalizer
   labels:
     app: {{ template "aerospike-cluster.commonName" . }}
     chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
+    # needed after first ako-3.3.0 reconciliation to allow scale-up
+    aerospike.com/api-version: v1
     {{- with .Values.customLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
* Add the api-version label
* This finalizer and label are applied by AKO if missing during a reconcile
* Helm may not keep AerospikeCluster changes made by AKO
* Hence it's important to define them in the chart.