### PR TITLE
Skip deletion of unhealthy pods during rolling restart

### DIFF
--- a/controllers/pod.go
+++ b/controllers/pod.go
@@ -236,9 +236,12 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 	if len(failedPods) != 0 {
 		r.Log.Info("Restart failed pods", "pods", getPodNames(failedPods))
 
-		if res := r.restartPods(rackState, failedPods, restartTypeMap, true); !res.isSuccess {
-			return res
-		}
+		// Criteo: It conflicts with decommission operations and we have an auto-heal reconciler in aerospikemanager.
+		// if res := r.restartPods(rackState, failedPods, restartTypeMap, true); !res.isSuccess {
+		// 	return res
+		// }
+
+		return reconcileError(fmt.Errorf("Pods %s are failing. Waiting for auto heal/manual intervention", strings.Join(getPodNames(failedPods), ",")))
 	}
 
 	if len(activePods) != 0 {


### PR DESCRIPTION
When an aerospike cluster is doing a rolling restart, we also may accept decommissions when the PDB opens up. When decommissioning a node, the pod will become unhealthy (pending) and so the Operator will try to restart it indefinitely because it is seen as failed.

With this commit, we want the operator to stop deleting the pod and let the aerospikemanager handle the auto-heal of the pod when it is unhealthy.

Jira:STO-12219