### PR TITLE
fix: make role create code stop always returning err in isCreate

### DIFF
--- a/controllers/access_control.go
+++ b/controllers/access_control.go
@@ -451,14 +451,16 @@ func (roleCreate aerospikeRoleCreateUpdate) execute(
 	}
 
 	if isCreate {
-		if err := roleCreate.createRole(client, adminPolicy, logger, recorder, aeroCluster); err != nil {
+		if errorCreate := roleCreate.createRole(client, adminPolicy, logger, recorder, aeroCluster); errorCreate != nil {
 			recorder.Eventf(
 				aeroCluster, corev1.EventTypeWarning, "RoleCreateFailed",
 				"Failed to Create Role %s", roleCreate.name,
 			)
+
+			return errorCreate
 		}
 
-		return err
+		return nil
 	}
 
 	if errorUpdate := roleCreate.updateRole(


### PR DESCRIPTION
There was a bug in aerospikeRoleCreateUpdate.execute where isCreate, reached when err from QueryRole contains "Invalid role", shadows that same err variable.

The err variable is shadowed in the "if err :=" block, goes out of scope, and the previous err ("Invalid role") is returned instead of nil. Fix this by renaming the error to avoid shadowing.