### PR TITLE
Restore missing criteo customizations from branch criteo-3.3.0

### DIFF
--- a/helm-charts/aerospike-cluster/templates/aerospike-cluster-cr.yaml
+++ b/helm-charts/aerospike-cluster/templates/aerospike-cluster-cr.yaml
@@ -3,10 +3,15 @@ kind: AerospikeCluster
 metadata:
   name: {{ template "aerospike-cluster.commonName" . }}
   namespace: {{ .Release.Namespace }}
+  # finalizer needed to handle pvc deletion when AerospikeCluster is deleted.
+  finalizers:
+    - asdb.aerospike.com/storage-finalizer
   labels:
     app: {{ template "aerospike-cluster.commonName" . }}
     chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
+    # needed after first ako-3.3.0 reconciliation to allow scale-up
+    aerospike.com/api-version: v1
     {{- with .Values.customLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
```
See diff from CRD from criteo-3.3.0 branch below

21c21
<   size: {{ .Values.replicas }}
---
>   size: {{ .Values.replicas | default 3 }}
22a23,26
>   # Control PodDisruptionBudget creation for the Aerospike cluster.
>   disablePDB: {{ .Values.disablePDB | default false}}
>   maxUnavailable: {{ if not .Values.disablePDB }}{{ .Values.maxUnavailable }}{{end}}
>
24c28
<   image: {{ .Values.image.repository | default "aerospike/aerospike-server-enterprise" }}:{{ .Values.image.tag | default "8.1.0.0" }}
---
>   image: {{ .Values.image.repository | default "aerospike/aerospike-server-enterprise" }}:{{ .Values.image.tag | default "7.1.0.0" }}
26,32d29
<   ## maxUnavailable defines percentage/number of pods that can be allowed to go down or unavailable
<   ## before application disruption.
<   maxUnavailable: {{ .Values.maxUnavailable }}
<
<   ## Disable the PodDisruptionBudget creation for the Aerospike cluster.
<   disablePDB: {{ .Values.disablePDB }}
<
65,67d61
<   ## enableDynamicConfigUpdate enables dynamic config update flow of the operator.
<   enableDynamicConfigUpdate: {{ .Values.enableDynamicConfigUpdate }}
<
124,151d117
<
<   ## headlessService defines additional configuration parameters for the headless service created to discover Aerospike Cluster nodes
<   {{- with .Values.headlessService }}
<   headlessService: {{- toYaml . | nindent 4 }}
<   {{- end }}
<
<   ## podService defines additional configuration parameters for the pod service created to expose the Aerospike Cluster nodes outside the Kubernetes cluster.
<   {{- with .Values.podService }}
<   podService: {{- toYaml . | nindent 4 }}
<   {{- end }}
<
<   ## rosterNodeBlockList is a list of blocked nodeIDs from roster in a strong-consistency setup
<   {{- with .Values.rosterNodeBlockList }}
<   rosterNodeBlockList: {{- toYaml . | nindent 4 }}
<   {{- end }}
<
<   ## k8sNodeBlockList is a list of Kubernetes nodes which are not used for Aerospike pods.
<   {{- with .Values.k8sNodeBlockList }}
<   k8sNodeBlockList: {{- toYaml . | nindent 4 }}
<   {{- end }}
<
<   ## operations is a list of on-demand operations to be performed on the Aerospike cluster.
<   {{- with .Values.operations }}
<   operations: {{- toYaml . | nindent 4 }}
<   {{- end }}
<
<   ## Pause reconciliation of the cluster
<   paused: {{ .Values.paused }}