### PR TITLE
criteo-specific AKO helm templates

### DIFF
--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikebackup-editor-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikebackup-editor-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aerospike-operator-aerospikebackup-editor-role
+  name: aerospike-operator-aerospikebackup-editor-role-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikebackup-viewer-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikebackup-viewer-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aerospike-operator-aerospikebackup-viewer-role
+  name: aerospike-operator-aerospikebackup-viewer-role-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikebackupservice-editor-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikebackupservice-editor-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aerospike-operator-aerospikebackupservice-editor-role
+  name: aerospike-operator-aerospikebackupservice-editor-role-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikebackupservice-viewer-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikebackupservice-viewer-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aerospike-operator-aerospikebackupservice-viewer-role
+  name: aerospike-operator-aerospikebackupservice-viewer-role-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikecluster-editor-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikecluster-editor-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aerospike-operator-aerospikecluster-editor-role
+  name: aerospike-operator-aerospikecluster-editor-role-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikecluster-viewer-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikecluster-viewer-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aerospike-operator-aerospikecluster-viewer-role
+  name: aerospike-operator-aerospikecluster-viewer-role-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikerestore-editor-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikerestore-editor-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aerospike-operator-aerospikerestore-editor-role
+  name: aerospike-operator-aerospikerestore-editor-role-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikerestore-viewer-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-aerospikerestore-viewer-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aerospike-operator-aerospikerestore-viewer-role
+  name: aerospike-operator-aerospikerestore-viewer-role-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-manager-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-manager-clusterrole.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: aerospike-operator-manager-role
+  name: aerospike-operator-manager-role-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-manager-clusterrolebinding.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-manager-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: aerospike-operator-manager-rolebinding
+  name: aerospike-operator-manager-rolebinding-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: aerospike-operator-manager-role
+  name: aerospike-operator-manager-role-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "aerospike-kubernetes-operator.fullname" . }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-metrics-auth-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-metrics-auth-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aerospike-operator-metrics-auth-role
+  name: aerospike-operator-metrics-auth-role-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-metrics-auth-clusterrolebinding.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-metrics-auth-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: aerospike-operator-metrics-auth-rolebinding
+  name: aerospike-operator-metrics-auth-rolebinding-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: aerospike-operator-metrics-auth-role
+  name: aerospike-operator-metrics-auth-role-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "aerospike-kubernetes-operator.fullname" . }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-mutating-webhook-configuration.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-mutating-webhook-configuration.yaml
@@ -3,7 +3,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/aerospike-operator-serving-cert
-  name: aerospike-operator-mutating-webhook-configuration
+  name: aerospike-operator-mutating-webhook-configuration-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}
@@ -11,6 +11,14 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
+  namespaceSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+        {{- range $value := split "," .Values.watchNamespaces }}
+        - "{{ $value }}"
+        {{- end }}
   clientConfig:
     service:
       name: aerospike-operator-webhook-service

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-validating-webhook-configuration.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-validating-webhook-configuration.yaml
@@ -3,7 +3,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/aerospike-operator-serving-cert
-  name: aerospike-operator-validating-webhook-configuration
+  name: aerospike-operator-validating-webhook-configuration-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" . }}
     chart: {{ .Chart.Name }}
@@ -11,6 +11,14 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
+  namespaceSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+        {{- range $value := split "," .Values.watchNamespaces }}
+        - "{{ $value }}"
+        {{- end }}
   clientConfig:
     service:
       name: aerospike-operator-webhook-service

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospikecluster-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospikecluster-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aerospike-cluster
+  name: aerospike-cluster-{{ .Release.Namespace }}
   labels:
     app: {{ template "aerospike-kubernetes-operator.fullname" $ }}
     chart: {{ $.Chart.Name }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospikecluster-clusterrolebinding.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospikecluster-clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aerospike-cluster-{{ .Release.Namespace }}
+  labels:
+    app: {{ template "aerospike-kubernetes-operator.fullname" . }}
+    chart: {{ $.Chart.Name }}
+    release: {{ $.Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aerospike-cluster-{{ .Release.Namespace }}
+subjects:
+{{- range $key, $ns := (split "," .Values.watchNamespaces) }}
+- kind: ServiceAccount
+  name: aerospike-operator-controller-manager
+  namespace: {{ $ns }}
+{{- end }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospikecluster-serviceaccount.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospikecluster-serviceaccount.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create }}
+{{- range $key, $ns := (split "," .Values.watchNamespaces) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  # hardcoded serviceaccount for aerospike statefulsets
+  name: aerospike-operator-controller-manager
+  namespace: {{ $ns }}
+  labels:
+    app: {{ include "aerospike-kubernetes-operator.fullname" $ }}
+    chart: {{ $.Chart.Name }}
+    release: {{ $.Release.Name }}
+{{- with $.Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- range . }}
+  - name: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
  - this PR combines the following changes squashed into one commit
    - make operator helm chart parallel installable f2157dd9f507088812d16fe2f272eecbffdcf95c
    - deploy missing of cluster rbac ba97a4b74ed528c0258af9451524544a8112e78a
    - use crto.in/namespace label instead of kubernetes.io/metadata.name eeac35a8973170221b167741d2b1b0eb9871c7a8