### PR TITLE
criteo-specific changes related to pod eviction

### DIFF
--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-manager-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-manager-clusterrole.yaml
@@ -115,4 +115,10 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
 {{- end }}

--- a/internal/controller/cluster/aero_info_calls.go
+++ b/internal/controller/cluster/aero_info_calls.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -84,8 +84,8 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 	 * Still an unquiesce in case of error during real eviction must be considered.
 	 */
 	for _, pod := range pods {
-		if err := r.KubeClient.CoreV1().Pods(pod.Namespace).Evict(context.TODO(),
-			&policyv1beta1.Eviction{
+		if err := r.KubeClient.PolicyV1().Evictions(pod.Namespace).Evict(context.TODO(),
+			&policyv1.Eviction{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      pod.Name,
 					Namespace: pod.Namespace,
@@ -96,7 +96,7 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 			}); err != nil {
 
 			r.Log.Info(fmt.Sprintf("Not evictable pod %s in ns %s. Won't quiesce and retry in 30sec. Error: %s", pod.Name, pod.Namespace, err.Error()))
-			return reconcileRequeueAfter(30)
+			return common.ReconcileRequeueAfter(30)
 		}
 	}
 
@@ -140,35 +140,19 @@ func (r *SingleClusterReconciler) quiesceUndoPods(policy *as.ClientPolicy, pods 
 		return err
 	}
 
-	/*
-	* HACK: Force a recluster with an empty list of hosts.
-	* Since aerospike-management-lib doesn't expose any "recluster" public function
-	* We are using InfoQuiesce to call "recluster" using an empty list of hosts too apply the QuiesceUndo.
-	 */
-	err = deployment.InfoQuiesceUndo(r.Log, policy, selectedHostConns)
+	allHostConns, err := r.newAllHostConnWithOption(sets.Set[string]{})
 	if err != nil {
-		// In any case (error or no error), the caller will reconcileRequeueAfter.
+		return err
+	}
+
+	if err = deployment.InfoQuiesceUndo(r.Log, policy, selectedHostConns); err != nil {
 		if strings.Contains(err.Error(), "failed to execute recluster command") {
-			return r.recluster(policy)
+			return deployment.InfoRecluster(r.Log, policy, allHostConns)
 		} else {
 			return err
 		}
 	}
 	return nil
-}
-
-/*
- * HACK: Force a recluster with an empty list of hosts.
- * Since aerospike-management-lib doesn't expose any "recluster" public function
- * We are using InfoQuiesce to call "recluster" using an empty list of hosts too apply the Quiesce.
- */
-func (r *SingleClusterReconciler) recluster(policy *as.ClientPolicy) error {
-
-	allHostConns, err := r.newAllHostConnWithOption(sets.Set[string]{})
-	if err != nil {
-		return err
-	}
-	return r.quiescePods(policy, allHostConns, []*corev1.Pod{}, sets.Set[string]{})
 }
 
 // TODO: Check only for migration

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -12,7 +12,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -416,7 +416,7 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 }
 
 func (r *SingleClusterReconciler) restartPods(
-	rackState *RackState, podsToRestart []*corev1.Pod, restartTypeMap map[string]RestartType, bypassPdb bool
+	rackState *RackState, podsToRestart []*corev1.Pod, restartTypeMap map[string]RestartType, bypassPdb bool,
 ) common.ReconcileResult {
 	// For each block volume removed from a namespace, pod status dirtyVolumes is appended with that volume name.
 	// For each file removed from a namespace, it is deleted right away.
@@ -427,6 +427,7 @@ func (r *SingleClusterReconciler) restartPods(
 	restartedPods := make([]*corev1.Pod, 0, len(podsToRestart))
 	restartedPodNames := make([]string, 0, len(podsToRestart))
 	restartedASDPodNames := make([]string, 0, len(podsToRestart))
+	failedEvictedPods := make([]*corev1.Pod, 0)
 
 	for idx := range podsToRestart {
 		pod := podsToRestart[idx]
@@ -444,7 +445,7 @@ func (r *SingleClusterReconciler) restartPods(
 		} else if restartType == podRestart {
 
 			if r.isLocalPVCDeletionRequired(rackState, pod) || bypassPdb {
-				if r.isLocalPVCDeletionRequired(rackState, pod){
+				if r.isLocalPVCDeletionRequired(rackState, pod) {
 					if err := r.deleteLocalPVCs(rackState, pod); err != nil {
 						return common.ReconcileError(err)
 					}
@@ -455,13 +456,9 @@ func (r *SingleClusterReconciler) restartPods(
 					return common.ReconcileError(err)
 				}
 
-				restartedPods = append(restartedPods, pod)
-				restartedPodNames = append(restartedPodNames, pod.Name)
-
-				r.Log.V(1).Info("Pod deleted", "podName", pod.Name)
 			} else {
-				if err := r.KubeClient.CoreV1().Pods(pod.Namespace).Evict(context.TODO(),
-					&policyv1beta1.Eviction{
+				if err := r.KubeClient.PolicyV1().Evictions(pod.Namespace).Evict(context.TODO(),
+					&policyv1.Eviction{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      pod.Name,
 							Namespace: pod.Namespace,
@@ -472,23 +469,23 @@ func (r *SingleClusterReconciler) restartPods(
 					failedEvictedPods = append(failedEvictedPods, pod)
 					continue
 				}
-				restartedPods = append(restartedPods, pod)
-				restartedPodNames = append(restartedPodNames, pod.Name)
-
-				r.Log.V(1).Info("Pod deleted", "podName", pod.Name)
 			}
-		}
-	}
+			restartedPods = append(restartedPods, pod)
+			restartedPodNames = append(restartedPodNames, pod.Name)
 
-	if err := r.updateOperationStatus(restartedASDPodNames, restartedPodNames); err != nil {
-		return common.ReconcileError(err)
+			r.Log.V(1).Info("Pod deleted", "podName", pod.Name)
+		}
 	}
 
 	if len(failedEvictedPods) > 0 {
 		if err := r.quiesceUndoPods(r.getClientPolicy(), failedEvictedPods); err != nil {
 			r.Log.Error(err, "Unexpected error during quiesce-undo command")
 		}
-		return reconcileRequeueAfter(30)
+		return common.ReconcileRequeueAfter(30)
+	}
+
+	if err := r.updateOperationStatus(restartedASDPodNames, restartedPodNames); err != nil {
+		return common.ReconcileError(err)
 	}
 
 	if len(restartedPods) > 0 {
@@ -680,6 +677,8 @@ func (r *SingleClusterReconciler) deletePodAndEnsureImageUpdated(
 		return common.ReconcileError(err)
 	}
 
+	failedEvictedPods := make([]*corev1.Pod, 0)
+
 	// Delete pods
 	for _, pod := range podsToUpdate {
 		if r.isLocalPVCDeletionRequired(rackState, pod) {
@@ -688,8 +687,17 @@ func (r *SingleClusterReconciler) deletePodAndEnsureImageUpdated(
 			}
 		}
 
-		if err := r.Client.Delete(context.TODO(), pod); err != nil {
-			return common.ReconcileError(err)
+		if err := r.KubeClient.PolicyV1().Evictions(pod.Namespace).Evict(context.TODO(),
+			&policyv1.Eviction{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pod.Name,
+					Namespace: pod.Namespace,
+				},
+			}); err != nil {
+			r.Log.Error(err, fmt.Sprintf("Not evictable pod %s in ns %s. Will QuiesceUndo and retry. Error: %s", pod.Name, pod.Namespace, err.Error()))
+			// in case of error during the eviction, unquiesce the node since it has been quiesced.
+			failedEvictedPods = append(failedEvictedPods, pod)
+			continue
 		}
 
 		r.Log.V(1).Info("Pod deleted", "podName", pod.Name)
@@ -697,6 +705,12 @@ func (r *SingleClusterReconciler) deletePodAndEnsureImageUpdated(
 			r.aeroCluster, corev1.EventTypeNormal, "PodWaitUpdate",
 			"[rack-%d] Waiting to update Pod %s", rackState.Rack.ID, pod.Name,
 		)
+	}
+
+	if len(failedEvictedPods) > 0 {
+		if err := r.quiesceUndoPods(r.getClientPolicy(), failedEvictedPods); err != nil {
+			r.Log.Error(err, "Unexpected error during quiesce-undo command")
+		}
 	}
 
 	return r.ensurePodsImageUpdated(podsToUpdate)


### PR DESCRIPTION
  - this change combines the following commits
    - Use eviction instead of deletion when restarting active pods 3098720
    - Fix of previous eviction backported changes a920d36
    - Use evict instead of delete when updating image 52c7533
    - Fix a few typos in controller/cluster/pod.go 5cf5c6e