### PR TITLE
criteo-specific changes related to stateful sets

### DIFF
--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -1856,10 +1856,107 @@ func isContainerNameInStorageVolumeAttachments(
 	return false
 }
 
+// CRITEO: Distribute nodes in given racks
+// It supports:
+//   - ClusterSize without racks defining Size (same as before)
+//   - ClusterSize > sum(Rack.Size) to distribute remaining nodes:
+//   - Either by assigning exclusively on Racks without size if any
+//
+// Kept the method quite "didactic" for clarity sake
+// Basically the algo is:
+//   - Assign nodes to rack with defined size.
+//   - Compute remainingNodes to assign
+//   - Assign them only on rack without defined size (zero)
+func splitRacksUnevenly(clusterSize int, racks []asdbv1.Rack) []int {
+	nodesAssigned := 0
+	racksWithoutNodes := 0
+	var topology []int
+
+	// Distribute nodes for Rack with defined size.
+	for rackIdx := range racks {
+		rackSize := int(racks[rackIdx].Size)
+		if rackSize == 0 {
+			racksWithoutNodes++
+		}
+		topology = append(topology, rackSize)
+		nodesAssigned += rackSize
+	}
+
+	remainingNodesToAssign := clusterSize - nodesAssigned
+
+	// Remaining nodes will be distributed across racks without size (ie. zero) if any
+	if remainingNodesToAssign == 0 {
+		return topology
+	} else if racksWithoutNodes > 0 {
+		var leftOverTopology []int
+		nodesPerRack, extraNodes := remainingNodesToAssign/racksWithoutNodes, remainingNodesToAssign%racksWithoutNodes
+		for rackIdx := 0; rackIdx < racksWithoutNodes; rackIdx++ {
+			nodesForThisRack := nodesPerRack
+			// This is mandatory to make sure we assign all remaining nodes.
+			// For example:
+			//   . racks:
+			//     . racks[0].Size = 0
+			//     . racks[1].Size = 0
+			//     . racks[2].Size = 0
+			//     . racks[3].Size = 1
+			//   . clusterSize: 12
+			//   . remainingNodesToAssign: 11
+			//   . racksWithoutNodes: 3
+			//   . nodesForThisRack: 11 / 3 -> 3
+			//   . extraNodes: 2
+			// This condition will guarantee that leftOverTopology[0] and [1]
+			// get an extra nodes each (rackIdx (0 and 1) < extraNodes (2)):
+			//   . leftOverTopology[0] = 4 (nodesForThisRack + 1)
+			//   . leftOverTopology[1] = 4 (nodesForThisRack + 1)
+			//   . leftOverTopology[2] = 3 (nodesForThisRack)
+			if rackIdx < extraNodes {
+				nodesForThisRack++
+			}
+			leftOverTopology = append(leftOverTopology, nodesForThisRack)
+		}
+		// Now that leftOverNodes has been assigned, update topology
+		leftOverIdx := 0
+		for rackIdx := range racks {
+			if topology[rackIdx] == 0 {
+				topology[rackIdx] = leftOverTopology[leftOverIdx]
+				leftOverIdx++
+			}
+		}
+	}
+
+	return topology
+}
+
+// CRITEO: Signature has been changed because we need each rack Size for the algo
+func splitRacks(nodes int, racks []asdbv1.Rack) []int {
+	/*
+		nodesPerRack, extraNodes := nodes/racks, nodes%racks
+		// Distributing nodes in given racks
+		var topology []int
+
+		for rackIdx := 0; rackIdx < racks; rackIdx++ {
+			nodesForThisRack := nodesPerRack
+			if rackIdx < extraNodes {
+				nodesForThisRack++
+			}
+			topology = append(topology, nodesForThisRack)
+		}
+		return topology
+	*/
+
+	// CRITEO: Call newly created method that allow uneven distribution of nodes
+	// Keeping above code in comment to ease merge from upstream
+	return splitRacksUnevenly(nodes, racks)
+}
+
+// CRITEO: to be able to test it, it needs to be exported (upperCase)
+func GetConfiguredRackStateList(aeroCluster *asdbv1.AerospikeCluster) []RackState {
+	return getConfiguredRackStateList(aeroCluster)
+}
+
 func getConfiguredRackStateList(aeroCluster *asdbv1.AerospikeCluster) []RackState {
-	topology := asdbv1.DistributeItems(
-		aeroCluster.Spec.Size, utils.Len32(aeroCluster.Spec.RackConfig.Racks),
-	)
+	// CRITEO: splitRacks has been adapted to support uneven Racks' node distribution
+	topology := splitRacks(int(aeroCluster.Spec.Size), aeroCluster.Spec.RackConfig.Racks)
 
 	rackStateList := make([]RackState, 0, len(aeroCluster.Spec.RackConfig.Racks))
 
@@ -1873,7 +1970,7 @@ func getConfiguredRackStateList(aeroCluster *asdbv1.AerospikeCluster) []RackStat
 		rackStateList = append(
 			rackStateList, RackState{
 				Rack: &racks[idx],
-				Size: topology[idx],
+				Size: int32(topology[idx]),
 			},
 		)
 	}

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -102,6 +102,7 @@ func (r *SingleClusterReconciler) createSTS(
 
 	ports := getSTSContainerPort(
 		r.aeroCluster.Spec.PodSpec.MultiPodPerHost,
+		r.aeroCluster.Spec.PodSpec.HostNetwork,
 		r.aeroCluster.Spec.AerospikeConfig,
 		&r.aeroCluster.Spec.AerospikeNetworkPolicy,
 	)
@@ -597,6 +598,7 @@ func (r *SingleClusterReconciler) updateSTSPorts(
 ) {
 	ports := getSTSContainerPort(
 		r.aeroCluster.Spec.PodSpec.MultiPodPerHost,
+		r.aeroCluster.Spec.PodSpec.HostNetwork,
 		r.aeroCluster.Spec.AerospikeConfig,
 		&r.aeroCluster.Spec.AerospikeNetworkPolicy,
 	)
@@ -1530,7 +1532,7 @@ func addVolumeDeviceInContainer(
 }
 
 func getSTSContainerPort(
-	multiPodPerHost *bool, aeroConf *asdbv1.AerospikeConfigSpec, aeroNetworkPolicy *asdbv1.AerospikeNetworkPolicy,
+	multiPodPerHost *bool, hostNetwork bool, aeroConf *asdbv1.AerospikeConfigSpec, aeroNetworkPolicy *asdbv1.AerospikeNetworkPolicy,
 ) []corev1.ContainerPort {
 	ports := make([]corev1.ContainerPort, 0, len(defaultContainerPorts))
 	portNames := make([]string, 0, len(defaultContainerPorts))
@@ -1571,12 +1573,12 @@ func getSTSContainerPort(
 			Protocol:      corev1.ProtocolTCP,
 		}
 		// Single pod per host. Enable hostPort setting
-		// when pod only network is not defined.
+		// when hostNetwork is true and pod only network is not defined.
 		// The hostPort setting applies to the Kubernetes containers.
 		// The container port will be exposed to the external network at <hostIP>:<hostPort>,
 		// where the hostIP is the IP address of the Kubernetes node where
 		// the container is running and the hostPort is the port requested by the user
-		if !asdbv1.GetBool(multiPodPerHost) && portInfo.exposedOnHost && !podOnlyNetwork {
+		if !asdbv1.GetBool(multiPodPerHost) && hostNetwork && portInfo.exposedOnHost && !podOnlyNetwork {
 			containerPort.HostPort = containerPort.ContainerPort
 		}
 

--- a/internal/webhook/v1/aerospikecluster_validating_webhook.go
+++ b/internal/webhook/v1/aerospikecluster_validating_webhook.go
@@ -253,8 +253,15 @@ func validate(aslog logr.Logger, cluster *asdbv1.AerospikeCluster) (admission.Wa
 		return warnings, err
 	}
 
+	// CRITEO: Compute sum of racks' size for further sanity check against cluster size
+	var rackedSize int32 = 0
+	allRackHaveSize := true
 	for idx := range cluster.Spec.RackConfig.Racks {
 		rack := &cluster.Spec.RackConfig.Racks[idx]
+		rackedSize += rack.Size
+		if rack.Size == 0 {
+			allRackHaveSize = false
+		}
 		// Storage should be validated before validating aerospikeConfig and fileStorage
 		if err := validateStorage(&rack.Storage, &cluster.Spec.PodSpec); err != nil {
 			return warnings, err
@@ -279,6 +286,12 @@ func validate(aslog logr.Logger, cluster *asdbv1.AerospikeCluster) (admission.Wa
 		); err != nil {
 			return warnings, err
 		}
+	}
+
+	// CRITEO: Validate that the sum of racks' size is lesser or equal to cluster size
+	// Or if it is strictly equal to cluster size in case all racks are defining a size
+	if err := validateRackSize(aslog, allRackHaveSize, rackedSize, cluster.Spec.Size); err != nil {
+		return warnings, err
 	}
 
 	// Validate resource and limit
@@ -718,6 +731,22 @@ func validateClusterSize(_ logr.Logger, sz int) error {
 	if sz > maxEnterpriseClusterSize {
 		return fmt.Errorf(
 			"cluster size cannot be more than %d", maxEnterpriseClusterSize,
+		)
+	}
+
+	return nil
+}
+
+// CRITEO: Validate that the sum of racks' size is lesser or equal to cluster size.
+func validateRackSize(_ logr.Logger, allRackHaveSize bool, rackedSize int32, clusterSize int32) error {
+	if allRackHaveSize && rackedSize != clusterSize {
+		return fmt.Errorf(
+			"all racks have a defined size. Sum of rack size %d must be equal to cluster size %d", rackedSize, clusterSize,
+		)
+	}
+	if rackedSize > clusterSize {
+		return fmt.Errorf(
+			"added rack size %d cannot be more than cluster size %d", rackedSize, clusterSize,
 		)
 	}
 

--- a/test/rack_size_test.go
+++ b/test/rack_size_test.go
@@ -1,0 +1,188 @@
+package test
+
+import (
+	"testing"
+
+	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/api/v1"
+	"github.com/aerospike/aerospike-kubernetes-operator/controllers"
+)
+
+func TestClusterSizeWithoutRackSize(t *testing.T) {
+	// Cluster size of 4 assigned to 3 racks
+	aeroCluster := &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 4}
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	racks := []asdbv1.Rack{
+		{ID: 1},
+		{ID: 2},
+		{ID: 3},
+	}
+	expectedRackSizeById := map[int]int{
+		1: 2,
+		2: 1,
+		3: 1,
+	}
+	aeroCluster.Spec.RackConfig.Racks = racks
+	rackStates := controllers.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		expectedSize := expectedRackSizeById[rackState.Rack.ID]
+		if rackState.Size != expectedSize {
+			t.Errorf(`rack %d with size %d does not match expected size of %d`, rackState.Rack.ID, rackState.Size, expectedSize)
+		}
+	}
+
+	// Cluster size of 7 assigned to 2 racks
+	aeroCluster = &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 7}
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	racks = []asdbv1.Rack{
+		{ID: 1},
+		{ID: 2},
+	}
+	expectedRackSizeById = map[int]int{
+		1: 4,
+		2: 3,
+	}
+	aeroCluster.Spec.RackConfig.Racks = racks
+	rackStates = controllers.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		expectedSize := expectedRackSizeById[rackState.Rack.ID]
+		if rackState.Size != expectedSize {
+			t.Errorf(`rack %d with size %d does not match expected size of %d`, rackState.Rack.ID, rackState.Size, expectedSize)
+		}
+	}
+
+	// Cluster size of 2 assigned to 3 racks
+	aeroCluster = &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 2}
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	racks = []asdbv1.Rack{
+		{ID: 1},
+		{ID: 2},
+		{ID: 3},
+	}
+	expectedRackSizeById = map[int]int{
+		1: 1,
+		2: 1,
+		3: 0,
+	}
+	aeroCluster.Spec.RackConfig.Racks = racks
+	rackStates = controllers.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		expectedSize := expectedRackSizeById[rackState.Rack.ID]
+		if rackState.Size != expectedSize {
+			t.Errorf(`rack %d with size %d does not match expected size of %d`, rackState.Rack.ID, rackState.Size, expectedSize)
+		}
+	}
+
+	// Cluster size of 2 assigned to 1 racks
+	aeroCluster = &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 2}
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	racks = []asdbv1.Rack{
+		{ID: 1},
+	}
+	expectedRackSizeById = map[int]int{
+		1: 2,
+	}
+	aeroCluster.Spec.RackConfig.Racks = racks
+	rackStates = controllers.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		expectedSize := expectedRackSizeById[rackState.Rack.ID]
+		if rackState.Size != expectedSize {
+			t.Errorf(`rack %d with size %d does not match expected size of %d`, rackState.Rack.ID, rackState.Size, expectedSize)
+		}
+	}
+
+	// Cluster size of 2 assigned to 2 racks
+	aeroCluster = &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 2}
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	racks = []asdbv1.Rack{
+		{ID: 1},
+		{ID: 2},
+	}
+	expectedRackSizeById = map[int]int{
+		1: 1,
+		2: 1,
+	}
+	aeroCluster.Spec.RackConfig.Racks = racks
+	rackStates = controllers.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		expectedSize := expectedRackSizeById[rackState.Rack.ID]
+		if rackState.Size != expectedSize {
+			t.Errorf(`rack %d with size %d does not match expected size of %d`, rackState.Rack.ID, rackState.Size, expectedSize)
+		}
+	}
+}
+
+func TestClusterSizeWithRackSize(t *testing.T) {
+	// Cluster size of 7 assigned to 3 racks
+	// All of them has defined size
+	aeroCluster := &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 7}
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	racks := []asdbv1.Rack{
+		{ID: 1, Size: 3},
+		{ID: 2, Size: 3},
+		{ID: 3, Size: 1},
+	}
+	expectedRackSizeById := map[int]int{
+		1: 3,
+		2: 3,
+		3: 1,
+	}
+	aeroCluster.Spec.RackConfig.Racks = racks
+	rackStates := controllers.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		expectedSize := expectedRackSizeById[rackState.Rack.ID]
+		if rackState.Size != expectedSize {
+			t.Errorf(`rack %d with size %d does not match expected size of %d`, rackState.Rack.ID, rackState.Size, expectedSize)
+		}
+	}
+
+	// Cluster size of 7 assigned to 4 racks
+	// Two of them has a defined size of 1
+	aeroCluster = &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 7}
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	racks = []asdbv1.Rack{
+		{ID: 1, Size: 1},
+		{ID: 2},
+		{ID: 3},
+		{ID: 4, Size: 1},
+	}
+	expectedRackSizeById = map[int]int{
+		1: 1,
+		2: 3,
+		3: 2,
+		4: 1,
+	}
+	aeroCluster.Spec.RackConfig.Racks = racks
+	rackStates = controllers.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		expectedSize := expectedRackSizeById[rackState.Rack.ID]
+		if rackState.Size != expectedSize {
+			t.Errorf(`rack %d with size %d does not match expected size of %d`, rackState.Rack.ID, rackState.Size, expectedSize)
+		}
+	}
+
+	// Cluster size of 4 assigned to 1 racks with size 4
+	aeroCluster = &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 4}
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	racks = []asdbv1.Rack{
+		{ID: 1, Size: 4},
+	}
+	expectedRackSizeById = map[int]int{
+		1: 4,
+	}
+	aeroCluster.Spec.RackConfig.Racks = racks
+	rackStates = controllers.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		expectedSize := expectedRackSizeById[rackState.Rack.ID]
+		if rackState.Size != expectedSize {
+			t.Errorf(`rack %d with size %d does not match expected size of %d`, rackState.Rack.ID, rackState.Size, expectedSize)
+		}
+	}
+}


### PR DESCRIPTION
  - this change combines the following commits
    - Support Rack with different Size 1567226
    - Avoid exposing pod hostPort when hostNetwork is false b96ffdb