### PR TITLE
aerospike-operator-metrics-reader cluster role suffixed with namespace

### DIFF
--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-metrics-reader.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-metrics-reader.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metrics-reader
+  name: metrics-reader-{{ .Release.Namespace }}
 rules:
 - nonResourceURLs:
   - "/metrics"


### PR DESCRIPTION
  - this ensure we can deploy one instance of AKO in several namespaces of the same kubernetes cluster