### PR TITLE
Align CRD generation with current CRD deployed

### DIFF
--- a/api/v1/aerospikecluster_types.go
+++ b/api/v1/aerospikecluster_types.go
@@ -413,6 +413,10 @@ type AerospikeInitContainerSpec struct { //nolint:govet // for readability
 	// +optional
 	ImageRegistry string `json:"imageRegistry,omitempty"`
 
+	// Image is the name of image for aerospike-init used with AKO criteo-3.3.0 this is to remove after bump to criteo-4.1.2 container image
+	// +optional
+	Image string `json:"image,omitempty"`
+
 	// ImageRegistryNamespace is the name of namespace in registry for aerospike-init container image
 	// +optional
 	ImageRegistryNamespace *string `json:"imageRegistryNamespace,omitempty"`
@@ -656,7 +660,7 @@ type AerospikePersistentVolumePolicySpec struct {
 
 	// WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
 	// changes.
-	// +kubebuilder:validation:Enum=dd;blkdiscard;deleteFiles
+	// +kubebuilder:validation:Enum=none;dd;blkdiscard;deleteFiles
 	// +optional
 	InputWipeMethod *AerospikeVolumeMethod `json:"wipeMethod,omitempty"`
 
@@ -672,7 +676,7 @@ type AerospikePersistentVolumePolicySpec struct {
 
 	// Effective/operative value to use as the volume wipe method after applying defaults.
 	// +optional
-	// +kubebuilder:validation:Enum=dd;blkdiscard;deleteFiles
+	// +kubebuilder:validation:Enum=none;dd;blkdiscard;deleteFiles
 	WipeMethod AerospikeVolumeMethod `json:"effectiveWipeMethod,omitempty"`
 
 	// Effective/operative value to use for cascade delete after applying defaults.

--- a/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml
+++ b/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml
@@ -713,6 +713,11 @@ spec:
                       AerospikeInitContainerSpec configures the aerospike-init container
                       created by the operator.
                     properties:
+                      image:
+                        description: Image is the name of image for aerospike-init
+                          used with AKO criteo-3.3.0 this is to remove after bump
+                          to criteo-4.1.2 container image
+                        type: string
                       imageNameAndTag:
                         description: ImageNameAndTag is the name:tag of aerospike-init
                           container image
@@ -6228,6 +6233,7 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -6249,6 +6255,7 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -6291,6 +6298,7 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -6312,6 +6320,7 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -6390,6 +6399,7 @@ spec:
                                     description: Effective/operative value to use
                                       as the volume wipe method after applying defaults.
                                     enum:
+                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -6783,6 +6793,7 @@ spec:
                                       WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                       changes.
                                     enum:
+                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -7839,6 +7850,7 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -7860,6 +7872,7 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -7902,6 +7915,7 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -7923,6 +7937,7 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -8001,6 +8016,7 @@ spec:
                                     description: Effective/operative value to use
                                       as the volume wipe method after applying defaults.
                                     enum:
+                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -8394,6 +8410,7 @@ spec:
                                       WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                       changes.
                                     enum:
+                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -8517,6 +8534,7 @@ spec:
                         description: Effective/operative value to use as the volume
                           wipe method after applying defaults.
                         enum:
+                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -8538,6 +8556,7 @@ spec:
                           WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                           changes.
                         enum:
+                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -8580,6 +8599,7 @@ spec:
                         description: Effective/operative value to use as the volume
                           wipe method after applying defaults.
                         enum:
+                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -8601,6 +8621,7 @@ spec:
                           WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                           changes.
                         enum:
+                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -8679,6 +8700,7 @@ spec:
                           description: Effective/operative value to use as the volume
                             wipe method after applying defaults.
                           enum:
+                          - none
                           - dd
                           - blkdiscard
                           - deleteFiles
@@ -9068,6 +9090,7 @@ spec:
                             WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                             changes.
                           enum:
+                          - none
                           - dd
                           - blkdiscard
                           - deleteFiles
@@ -9783,6 +9806,11 @@ spec:
                       AerospikeInitContainerSpec configures the aerospike-init container
                       created by the operator.
                     properties:
+                      image:
+                        description: Image is the name of image for aerospike-init
+                          used with AKO criteo-3.3.0 this is to remove after bump
+                          to criteo-4.1.2 container image
+                        type: string
                       imageNameAndTag:
                         description: ImageNameAndTag is the name:tag of aerospike-init
                           container image
@@ -15441,6 +15469,7 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -15462,6 +15491,7 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -15504,6 +15534,7 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -15525,6 +15556,7 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -15603,6 +15635,7 @@ spec:
                                     description: Effective/operative value to use
                                       as the volume wipe method after applying defaults.
                                     enum:
+                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -15996,6 +16029,7 @@ spec:
                                       WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                       changes.
                                     enum:
+                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -17052,6 +17086,7 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -17073,6 +17108,7 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -17115,6 +17151,7 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -17136,6 +17173,7 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
+                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -17214,6 +17252,7 @@ spec:
                                     description: Effective/operative value to use
                                       as the volume wipe method after applying defaults.
                                     enum:
+                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -17607,6 +17646,7 @@ spec:
                                       WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                       changes.
                                     enum:
+                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -17796,6 +17836,7 @@ spec:
                         description: Effective/operative value to use as the volume
                           wipe method after applying defaults.
                         enum:
+                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -17817,6 +17858,7 @@ spec:
                           WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                           changes.
                         enum:
+                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -17859,6 +17901,7 @@ spec:
                         description: Effective/operative value to use as the volume
                           wipe method after applying defaults.
                         enum:
+                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -17880,6 +17923,7 @@ spec:
                           WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                           changes.
                         enum:
+                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -17958,6 +18002,7 @@ spec:
                           description: Effective/operative value to use as the volume
                             wipe method after applying defaults.
                           enum:
+                          - none
                           - dd
                           - blkdiscard
                           - deleteFiles
@@ -18347,6 +18392,7 @@ spec:
                             WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                             changes.
                           enum:
+                          - none
                           - dd
                           - blkdiscard
                           - deleteFiles

--- a/helm-charts/aerospike-kubernetes-operator/crds/customresourcedefinition_aerospikeclusters.asdb.aerospike.com.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/crds/customresourcedefinition_aerospikeclusters.asdb.aerospike.com.yaml
@@ -714,8 +714,9 @@ spec:
                       created by the operator.
                     properties:
                       image:
-                        description: Image is the name of image for aerospike-init used with AKO criteo-3.3.0 this is to remove after bump to criteo-4.1.2
-                          container image
+                        description: Image is the name of image for aerospike-init
+                          used with AKO criteo-3.3.0 this is to remove after bump
+                          to criteo-4.1.2 container image
                         type: string
                       imageNameAndTag:
                         description: ImageNameAndTag is the name:tag of aerospike-init
@@ -9806,8 +9807,9 @@ spec:
                       created by the operator.
                     properties:
                       image:
-                        description: Image is the name of image for aerospike-init used with AKO criteo-3.3.0 this is to remove after bump to criteo-4.1.2
-                          container image
+                        description: Image is the name of image for aerospike-init
+                          used with AKO criteo-3.3.0 this is to remove after bump
+                          to criteo-4.1.2 container image
                         type: string
                       imageNameAndTag:
                         description: ImageNameAndTag is the name:tag of aerospike-init


### PR DESCRIPTION
* Image field in AerospikeInitContainerSpec was present in 3.3.0 but not in 4.1.2
* It has been kept during bump of 4.1.2 only in the CRD but not in the code used for generation.
* Restore it to avoid manual action on CRD when adding feature to 4.1.2
* Will be removed as soon as Aerospike 8.1 and 4.1.2 is live in prod WW