### PR TITLE
Support rack-id override at ns level per rack

### DIFF
--- a/internal/webhook/v1/aerospikecluster_mutating_webhook.go
+++ b/internal/webhook/v1/aerospikecluster_mutating_webhook.go
@@ -440,6 +440,17 @@ func setDefaultNsConf(asLog logr.Logger, configSpec asdbv1.AerospikeConfigSpec,
 							delete(nsMap, "rack-id")
 						}
 
+						// CRITEO: Allow override of rack-id by storing it in a dedicated variable to restore it after default value assignation.
+						// We have RackID which is the rack.id in aerospikecluster defining the STS name.
+						// And we have rack-id at namespace level in aerospike.conf which is the availability zone (domain failure) for rack-awareness.
+						// Operator mutation webhook forces that namespace rack-id field is equal to its aerospikecluster rack.id defining the STS name.
+						// cf. https://aerospike.com/docs/database/manage/namespace/rack-aware/#statically-assign-a-rack-in-an-ap-namespace
+						var nsRackId interface{}
+						if value, ok := nsMap["rack-id"]; ok {
+							nsRackId = value
+							delete(nsMap, "rack-id")
+						}
+
 						if err := setDefaultsInConfigMap(
 							asLog, nsMap, defaultConfs,
 						); err != nil {
@@ -447,6 +458,11 @@ func setDefaultNsConf(asLog logr.Logger, configSpec asdbv1.AerospikeConfigSpec,
 								"failed to set default aerospikeConfig.namespaces rack config: %v",
 								err,
 							)
+						}
+
+						// CRITEO: Restore the value of rack-id after setDefaultsInConfigMap if it was set
+						if nsRackId != nil {
+							nsMap["rack-id"] = nsRackId
 						}
 					} else {
 						// Deleting rack-id for namespaces in global config.

--- a/test/cluster/mutating_webhook_test.go
+++ b/test/cluster/mutating_webhook_test.go
@@ -309,3 +309,69 @@ func TestMutatingWebhook_RackPodSpec_DNSConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestMutatingWebhook_RackID_Override(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputRackID    interface{}
+		expectedRackID float64
+	}{
+		{
+			name:           "rack-id already set with different value is preserved",
+			inputRackID:    float64(99),
+			expectedRackID: float64(99),
+		},
+		{
+			name:           "rack-id already set with same value as rack ID is preserved",
+			inputRackID:    float64(1),
+			expectedRackID: float64(1),
+		},
+		{
+			name:           "rack-id not set gets default from rack ID",
+			inputRackID:    nil,
+			expectedRackID: float64(1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := createMinimalCluster()
+			cluster.Spec.RackConfig.Namespaces = []string{"test"}
+
+			// Build rack with optional InputAerospikeConfig containing rack-id override
+			rack := asdbv1.Rack{ID: 1}
+			if tt.inputRackID != nil {
+				rack.InputAerospikeConfig = &asdbv1.AerospikeConfigSpec{
+					Value: map[string]interface{}{
+						"namespaces": []interface{}{
+							map[string]interface{}{
+								"name":    "test",
+								"rack-id": tt.inputRackID,
+							},
+						},
+					},
+				}
+			}
+			cluster.Spec.RackConfig.Racks = []asdbv1.Rack{rack}
+
+			// Call the mutating webhook defaulter
+			defaulter := &webhookv1.AerospikeClusterCustomDefaulter{}
+			err := defaulter.Default(context.Background(), cluster)
+			if err != nil {
+				t.Fatalf("Default() failed: %v", err)
+			}
+
+			// Check the rack-id in the rack's aerospike config
+			resultRack := cluster.Spec.RackConfig.Racks[0]
+			rackNamespaces := resultRack.AerospikeConfig.Value["namespaces"].([]interface{})
+			rackNsMap := rackNamespaces[0].(map[string]interface{})
+			actualRackID, ok := rackNsMap["rack-id"]
+			if !ok {
+				t.Fatalf("rack-id not found in namespace config")
+			}
+			if actualRackID != tt.expectedRackID {
+				t.Errorf("expected rack-id=%v, got %v", tt.expectedRackID, actualRackID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Explanation:
* We have RackID which is the rack.id in aerospikecluster defining the STS name.
* And we have rack-id at namespace level in aerospike.conf which is the availability zone (domain failure) for rack-awareness.
* Operator mutation webhook forces that namespace rack-id field is equal to its aerospikecluster rack.id defining the STS name.
* It's already a feature available in Aerospike
  * cf. https://aerospike.com/docs/database/manage/namespace/rack-aware/#statically-assign-a-rack-in-an-ap-namespace