### PR TITLE
Remove init image fields in CRD and enum value None from wipeMethod

### DIFF
--- a/api/v1/aerospikecluster_types.go
+++ b/api/v1/aerospikecluster_types.go
@@ -413,10 +413,6 @@ type AerospikeInitContainerSpec struct { //nolint:govet // for readability
 	// +optional
 	ImageRegistry string `json:"imageRegistry,omitempty"`
 
-	// Image is the name of image for aerospike-init used with AKO criteo-3.3.0 this is to remove after bump to criteo-4.1.2 container image
-	// +optional
-	Image string `json:"image,omitempty"`
-
 	// ImageRegistryNamespace is the name of namespace in registry for aerospike-init container image
 	// +optional
 	ImageRegistryNamespace *string `json:"imageRegistryNamespace,omitempty"`
@@ -677,7 +673,7 @@ type AerospikePersistentVolumePolicySpec struct {
 
 	// WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
 	// changes.
-	// +kubebuilder:validation:Enum=none;dd;blkdiscard;deleteFiles
+	// +kubebuilder:validation:Enum=dd;blkdiscard;deleteFiles
 	// +optional
 	InputWipeMethod *AerospikeVolumeMethod `json:"wipeMethod,omitempty"`
 
@@ -693,7 +689,7 @@ type AerospikePersistentVolumePolicySpec struct {
 
 	// Effective/operative value to use as the volume wipe method after applying defaults.
 	// +optional
-	// +kubebuilder:validation:Enum=none;dd;blkdiscard;deleteFiles
+	// +kubebuilder:validation:Enum=dd;blkdiscard;deleteFiles
 	WipeMethod AerospikeVolumeMethod `json:"effectiveWipeMethod,omitempty"`
 
 	// Effective/operative value to use for cascade delete after applying defaults.

--- a/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml
+++ b/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml
@@ -713,11 +713,6 @@ spec:
                       AerospikeInitContainerSpec configures the aerospike-init container
                       created by the operator.
                     properties:
-                      image:
-                        description: Image is the name of image for aerospike-init
-                          used with AKO criteo-3.3.0 this is to remove after bump
-                          to criteo-4.1.2 container image
-                        type: string
                       imageNameAndTag:
                         description: ImageNameAndTag is the name:tag of aerospike-init
                           container image
@@ -6289,7 +6284,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -6311,7 +6305,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -6354,7 +6347,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -6376,7 +6368,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -6455,7 +6446,6 @@ spec:
                                     description: Effective/operative value to use
                                       as the volume wipe method after applying defaults.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -6849,7 +6839,6 @@ spec:
                                       WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                       changes.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -7962,7 +7951,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -7984,7 +7972,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -8027,7 +8014,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -8049,7 +8035,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -8128,7 +8113,6 @@ spec:
                                     description: Effective/operative value to use
                                       as the volume wipe method after applying defaults.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -8522,7 +8506,6 @@ spec:
                                       WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                       changes.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -8646,7 +8629,6 @@ spec:
                         description: Effective/operative value to use as the volume
                           wipe method after applying defaults.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -8668,7 +8650,6 @@ spec:
                           WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                           changes.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -8711,7 +8692,6 @@ spec:
                         description: Effective/operative value to use as the volume
                           wipe method after applying defaults.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -8733,7 +8713,6 @@ spec:
                           WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                           changes.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -8812,7 +8791,6 @@ spec:
                           description: Effective/operative value to use as the volume
                             wipe method after applying defaults.
                           enum:
-                          - none
                           - dd
                           - blkdiscard
                           - deleteFiles
@@ -9202,7 +9180,6 @@ spec:
                             WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                             changes.
                           enum:
-                          - none
                           - dd
                           - blkdiscard
                           - deleteFiles
@@ -9918,11 +9895,6 @@ spec:
                       AerospikeInitContainerSpec configures the aerospike-init container
                       created by the operator.
                     properties:
-                      image:
-                        description: Image is the name of image for aerospike-init
-                          used with AKO criteo-3.3.0 this is to remove after bump
-                          to criteo-4.1.2 container image
-                        type: string
                       imageNameAndTag:
                         description: ImageNameAndTag is the name:tag of aerospike-init
                           container image
@@ -15637,7 +15609,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -15659,7 +15630,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -15702,7 +15672,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -15724,7 +15693,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -15803,7 +15771,6 @@ spec:
                                     description: Effective/operative value to use
                                       as the volume wipe method after applying defaults.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -16197,7 +16164,6 @@ spec:
                                       WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                       changes.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -17310,7 +17276,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -17332,7 +17297,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -17375,7 +17339,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -17397,7 +17360,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -17476,7 +17438,6 @@ spec:
                                     description: Effective/operative value to use
                                       as the volume wipe method after applying defaults.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -17870,7 +17831,6 @@ spec:
                                       WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                       changes.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -18060,7 +18020,6 @@ spec:
                         description: Effective/operative value to use as the volume
                           wipe method after applying defaults.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -18082,7 +18041,6 @@ spec:
                           WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                           changes.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -18125,7 +18083,6 @@ spec:
                         description: Effective/operative value to use as the volume
                           wipe method after applying defaults.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -18147,7 +18104,6 @@ spec:
                           WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                           changes.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -18226,7 +18182,6 @@ spec:
                           description: Effective/operative value to use as the volume
                             wipe method after applying defaults.
                           enum:
-                          - none
                           - dd
                           - blkdiscard
                           - deleteFiles
@@ -18616,7 +18571,6 @@ spec:
                             WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                             changes.
                           enum:
-                          - none
                           - dd
                           - blkdiscard
                           - deleteFiles

--- a/helm-charts/aerospike-kubernetes-operator/crds/customresourcedefinition_aerospikeclusters.asdb.aerospike.com.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/crds/customresourcedefinition_aerospikeclusters.asdb.aerospike.com.yaml
@@ -713,11 +713,6 @@ spec:
                       AerospikeInitContainerSpec configures the aerospike-init container
                       created by the operator.
                     properties:
-                      image:
-                        description: Image is the name of image for aerospike-init
-                          used with AKO criteo-3.3.0 this is to remove after bump
-                          to criteo-4.1.2 container image
-                        type: string
                       imageNameAndTag:
                         description: ImageNameAndTag is the name:tag of aerospike-init
                           container image
@@ -6289,7 +6284,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -6311,7 +6305,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -6354,7 +6347,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -6376,7 +6368,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -6455,7 +6446,6 @@ spec:
                                     description: Effective/operative value to use
                                       as the volume wipe method after applying defaults.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -6849,7 +6839,6 @@ spec:
                                       WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                       changes.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -7962,7 +7951,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -7984,7 +7972,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -8027,7 +8014,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -8049,7 +8035,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -8128,7 +8113,6 @@ spec:
                                     description: Effective/operative value to use
                                       as the volume wipe method after applying defaults.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -8522,7 +8506,6 @@ spec:
                                       WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                       changes.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -8646,7 +8629,6 @@ spec:
                         description: Effective/operative value to use as the volume
                           wipe method after applying defaults.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -8668,7 +8650,6 @@ spec:
                           WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                           changes.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -8711,7 +8692,6 @@ spec:
                         description: Effective/operative value to use as the volume
                           wipe method after applying defaults.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -8733,7 +8713,6 @@ spec:
                           WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                           changes.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -8812,7 +8791,6 @@ spec:
                           description: Effective/operative value to use as the volume
                             wipe method after applying defaults.
                           enum:
-                          - none
                           - dd
                           - blkdiscard
                           - deleteFiles
@@ -9202,7 +9180,6 @@ spec:
                             WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                             changes.
                           enum:
-                          - none
                           - dd
                           - blkdiscard
                           - deleteFiles
@@ -9918,11 +9895,6 @@ spec:
                       AerospikeInitContainerSpec configures the aerospike-init container
                       created by the operator.
                     properties:
-                      image:
-                        description: Image is the name of image for aerospike-init
-                          used with AKO criteo-3.3.0 this is to remove after bump
-                          to criteo-4.1.2 container image
-                        type: string
                       imageNameAndTag:
                         description: ImageNameAndTag is the name:tag of aerospike-init
                           container image
@@ -15637,7 +15609,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -15659,7 +15630,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -15702,7 +15672,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -15724,7 +15693,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -15803,7 +15771,6 @@ spec:
                                     description: Effective/operative value to use
                                       as the volume wipe method after applying defaults.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -16197,7 +16164,6 @@ spec:
                                       WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                       changes.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -17310,7 +17276,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -17332,7 +17297,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -17375,7 +17339,6 @@ spec:
                                   description: Effective/operative value to use as
                                     the volume wipe method after applying defaults.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -17397,7 +17360,6 @@ spec:
                                     WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                     changes.
                                   enum:
-                                  - none
                                   - dd
                                   - blkdiscard
                                   - deleteFiles
@@ -17476,7 +17438,6 @@ spec:
                                     description: Effective/operative value to use
                                       as the volume wipe method after applying defaults.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -17870,7 +17831,6 @@ spec:
                                       WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                                       changes.
                                     enum:
-                                    - none
                                     - dd
                                     - blkdiscard
                                     - deleteFiles
@@ -18060,7 +18020,6 @@ spec:
                         description: Effective/operative value to use as the volume
                           wipe method after applying defaults.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -18082,7 +18041,6 @@ spec:
                           WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                           changes.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -18125,7 +18083,6 @@ spec:
                         description: Effective/operative value to use as the volume
                           wipe method after applying defaults.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -18147,7 +18104,6 @@ spec:
                           WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                           changes.
                         enum:
-                        - none
                         - dd
                         - blkdiscard
                         - deleteFiles
@@ -18226,7 +18182,6 @@ spec:
                           description: Effective/operative value to use as the volume
                             wipe method after applying defaults.
                           enum:
-                          - none
                           - dd
                           - blkdiscard
                           - deleteFiles
@@ -18616,7 +18571,6 @@ spec:
                             WipeMethod determines how volumes attached to Aerospike server pods are wiped for dealing with storage format
                             changes.
                           enum:
-                          - none
                           - dd
                           - blkdiscard
                           - deleteFiles


### PR DESCRIPTION
* It was kept for retro-compatibility between bump of 3.3.0 to 4.1.2.
* To keep a way to rollback easily.
* No more needed