### PR TITLE
Roll restart an Aerospike cluster when changing podSpec on cluster level

### DIFF
--- a/internal/controller/cluster/configmap.go
+++ b/internal/controller/cluster/configmap.go
@@ -199,9 +199,20 @@ func createPodSpecForRack(
 		&aeroCluster.Spec.PodSpec,
 	).(*asdbv1.AerospikePodSpec)
 
-	rackFullPodSpec.Affinity = rack.PodSpec.Affinity
-	rackFullPodSpec.Tolerations = rack.PodSpec.Tolerations
-	rackFullPodSpec.NodeSelector = rack.PodSpec.NodeSelector
+	// CRITEO: Force rolling restart when changing affinity on cluster level
+	if rack.PodSpec.Affinity != nil {
+		rackFullPodSpec.Affinity = rack.PodSpec.Affinity
+	}
+
+	// CRITEO: Force rolling restart when changing tolerations on cluster level
+	if rack.PodSpec.Tolerations != nil {
+		rackFullPodSpec.Tolerations = rack.PodSpec.Tolerations
+	}
+
+	// CRITEO: Force rolling restart when changing node selector on cluster level
+	if rack.PodSpec.NodeSelector != nil {
+		rackFullPodSpec.NodeSelector = rack.PodSpec.NodeSelector
+	}
 
 	// CRITEO: Include rack-level HostNetwork/DNSPolicy/DNSConfig overrides in hash computation
 	// to trigger rolling restart when these fields change at the rack level

--- a/internal/controller/cluster/configmap_test.go
+++ b/internal/controller/cluster/configmap_test.go
@@ -1,0 +1,221 @@
+package cluster
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
+	"github.com/aerospike/aerospike-kubernetes-operator/v4/pkg/utils"
+)
+
+// computePodSpecHash mirrors the hash logic in getSTSConfData for testing purposes.
+func computePodSpecHash(aeroCluster *asdbv1.AerospikeCluster, rack *asdbv1.Rack) (string, error) {
+	podSpec := createPodSpecForRack(aeroCluster, rack)
+
+	podSpecStr, err := json.Marshal(podSpec)
+	if err != nil {
+		return "", err
+	}
+
+	podSpecStr = []byte(strings.ReplaceAll(
+		string(podSpecStr), "\"aerospikeInitContainer\":{},", "",
+	))
+	podSpecStr = []byte(strings.ReplaceAll(
+		string(podSpecStr), "\"multiPodPerHost\":false,", "",
+	))
+
+	return utils.GetHash(string(podSpecStr))
+}
+
+func newCluster(affinity *corev1.Affinity, tolerations []corev1.Toleration, nodeSelector map[string]string,
+) *asdbv1.AerospikeCluster {
+	return &asdbv1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: asdbv1.AerospikeClusterSpec{
+			PodSpec: asdbv1.AerospikePodSpec{
+				SchedulingPolicy: asdbv1.SchedulingPolicy{
+					Affinity:     affinity,
+					Tolerations:  tolerations,
+					NodeSelector: nodeSelector,
+				},
+			},
+		},
+	}
+}
+
+func TestPodSpecHash_ClusterAffinityChange(t *testing.T) {
+	rack := &asdbv1.Rack{ID: 1}
+
+	clusterBefore := newCluster(nil, nil, nil)
+	hashBefore, err := computePodSpecHash(clusterBefore, rack)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clusterAfter := newCluster(&corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{MatchExpressions: []corev1.NodeSelectorRequirement{
+						{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1"}},
+					}},
+				},
+			},
+		},
+	}, nil, nil)
+	hashAfter, err := computePodSpecHash(clusterAfter, rack)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hashBefore == hashAfter {
+		t.Fatal("expected hash to change when cluster-level affinity is added, but it didn't")
+	}
+}
+
+func TestPodSpecHash_ClusterTolerationsChange(t *testing.T) {
+	rack := &asdbv1.Rack{ID: 1}
+
+	clusterBefore := newCluster(nil, nil, nil)
+	hashBefore, err := computePodSpecHash(clusterBefore, rack)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clusterAfter := newCluster(nil, []corev1.Toleration{
+		{Key: "key1", Operator: corev1.TolerationOpEqual, Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+	}, nil)
+	hashAfter, err := computePodSpecHash(clusterAfter, rack)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hashBefore == hashAfter {
+		t.Fatal("expected hash to change when cluster-level tolerations are added, but it didn't")
+	}
+}
+
+func TestPodSpecHash_ClusterNodeSelectorChange(t *testing.T) {
+	rack := &asdbv1.Rack{ID: 1}
+
+	clusterBefore := newCluster(nil, nil, nil)
+	hashBefore, err := computePodSpecHash(clusterBefore, rack)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clusterAfter := newCluster(nil, nil, map[string]string{"disktype": "ssd"})
+	hashAfter, err := computePodSpecHash(clusterAfter, rack)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hashBefore == hashAfter {
+		t.Fatal("expected hash to change when cluster-level nodeSelector is added, but it didn't")
+	}
+}
+
+func TestPodSpecHash_NoChangeWhenNothingChanges(t *testing.T) {
+	rack := &asdbv1.Rack{ID: 1}
+
+	cluster1 := newCluster(&corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{MatchExpressions: []corev1.NodeSelectorRequirement{
+						{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1"}},
+					}},
+				},
+			},
+		},
+	}, []corev1.Toleration{
+		{Key: "key1", Operator: corev1.TolerationOpEqual, Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+	}, map[string]string{"disktype": "ssd"})
+
+	cluster2 := newCluster(&corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{MatchExpressions: []corev1.NodeSelectorRequirement{
+						{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1"}},
+					}},
+				},
+			},
+		},
+	}, []corev1.Toleration{
+		{Key: "key1", Operator: corev1.TolerationOpEqual, Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+	}, map[string]string{"disktype": "ssd"})
+
+	hash1, err := computePodSpecHash(cluster1, rack)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash2, err := computePodSpecHash(cluster2, rack)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hash1 != hash2 {
+		t.Fatal("expected hash to be the same when nothing changes")
+	}
+}
+
+func TestPodSpecHash_RackOverrideDoesNotChangeOnClusterChange(t *testing.T) {
+	rackAffinity := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{MatchExpressions: []corev1.NodeSelectorRequirement{
+						{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"eu-west-1"}},
+					}},
+				},
+			},
+		},
+	}
+	rack := &asdbv1.Rack{
+		ID: 1,
+		PodSpec: asdbv1.RackPodSpec{
+			SchedulingPolicy: asdbv1.SchedulingPolicy{
+				Affinity:     rackAffinity,
+				Tolerations:  []corev1.Toleration{{Key: "rk", Operator: corev1.TolerationOpExists}},
+				NodeSelector: map[string]string{"rack": "1"},
+			},
+		},
+	}
+
+	// Cluster with no scheduling policy
+	clusterBefore := newCluster(nil, nil, nil)
+	hashBefore, err := computePodSpecHash(clusterBefore, rack)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Cluster with different scheduling policy — should not affect hash because rack overrides all fields
+	clusterAfter := newCluster(&corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{MatchExpressions: []corev1.NodeSelectorRequirement{
+						{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"ap-south-1"}},
+					}},
+				},
+			},
+		},
+	}, []corev1.Toleration{
+		{Key: "other", Operator: corev1.TolerationOpExists},
+	}, map[string]string{"cluster": "main"})
+
+	hashAfter, err := computePodSpecHash(clusterAfter, rack)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hashBefore != hashAfter {
+		t.Fatal("expected hash to stay the same when rack overrides all scheduling fields, regardless of cluster-level changes")
+	}
+}

--- a/test/cluster/rack_scheduling_policy_test.go
+++ b/test/cluster/rack_scheduling_policy_test.go
@@ -1,0 +1,213 @@
+package cluster
+
+import (
+	"testing"
+
+	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
+	"github.com/aerospike/aerospike-kubernetes-operator/v4/internal/controller/cluster"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestAffinityWithoutRackOverride(t *testing.T) {
+	// cluster-level affinity set, no rack override
+	// Expected: both racks should have nil PodSpec.Affinity (no override)
+	clusterAffinity := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	aeroCluster := &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 2}
+	aeroCluster.Spec.PodSpec.Affinity = clusterAffinity
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	aeroCluster.Spec.RackConfig.Racks = []asdbv1.Rack{
+		{ID: 1, Size: 1},
+		{ID: 2, Size: 1},
+	}
+
+	rackStates := cluster.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		if rackState.Rack.PodSpec.Affinity != nil {
+			t.Errorf("rack %d should have nil PodSpec.Affinity when no rack override is set", rackState.Rack.ID)
+		}
+	}
+}
+
+func TestAffinityWithRackOverride(t *testing.T) {
+	// cluster-level affinity set, rack 1 overrides with different affinity via effective PodSpec
+	clusterAffinity := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	rackAffinity := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"eu-west-1"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	aeroCluster := &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 2}
+	aeroCluster.Spec.PodSpec.Affinity = clusterAffinity
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	aeroCluster.Spec.RackConfig.Racks = []asdbv1.Rack{
+		{ID: 1, Size: 1, PodSpec: asdbv1.RackPodSpec{
+			SchedulingPolicy: asdbv1.SchedulingPolicy{Affinity: rackAffinity},
+		}},
+		{ID: 2, Size: 1},
+	}
+
+	expectedAffinityByID := map[int]*corev1.Affinity{
+		1: rackAffinity,
+		2: nil,
+	}
+
+	rackStates := cluster.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		expected := expectedAffinityByID[rackState.Rack.ID]
+		actual := rackState.Rack.PodSpec.Affinity
+		if expected == nil && actual != nil {
+			t.Errorf("rack %d expected nil affinity, got non-nil", rackState.Rack.ID)
+		}
+		if expected != nil && actual == nil {
+			t.Errorf("rack %d expected non-nil affinity, got nil", rackState.Rack.ID)
+		}
+		if expected != nil && actual != nil {
+			actualVal := actual.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.
+				NodeSelectorTerms[0].MatchExpressions[0].Values[0]
+			expectedVal := expected.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.
+				NodeSelectorTerms[0].MatchExpressions[0].Values[0]
+			if actualVal != expectedVal {
+				t.Errorf("rack %d expected affinity zone %s, got %s", rackState.Rack.ID, expectedVal, actualVal)
+			}
+		}
+	}
+}
+
+func TestTolerationsWithoutRackOverride(t *testing.T) {
+	// cluster-level tolerations set, no rack override
+	aeroCluster := &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 2}
+	aeroCluster.Spec.PodSpec.Tolerations = []corev1.Toleration{
+		{Key: "key1", Operator: corev1.TolerationOpEqual, Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+	}
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	aeroCluster.Spec.RackConfig.Racks = []asdbv1.Rack{
+		{ID: 1, Size: 1},
+		{ID: 2, Size: 1},
+	}
+
+	rackStates := cluster.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		if len(rackState.Rack.PodSpec.Tolerations) != 0 {
+			t.Errorf("rack %d should have empty PodSpec.Tolerations when no rack override is set", rackState.Rack.ID)
+		}
+	}
+}
+
+func TestTolerationsWithRackOverride(t *testing.T) {
+	// cluster-level tolerations set, rack 1 overrides via effective PodSpec
+	rackTolerations := []corev1.Toleration{
+		{Key: "rackKey", Operator: corev1.TolerationOpEqual, Value: "rackVal", Effect: corev1.TaintEffectNoExecute},
+	}
+
+	aeroCluster := &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 2}
+	aeroCluster.Spec.PodSpec.Tolerations = []corev1.Toleration{
+		{Key: "key1", Operator: corev1.TolerationOpEqual, Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+	}
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	aeroCluster.Spec.RackConfig.Racks = []asdbv1.Rack{
+		{ID: 1, Size: 1, PodSpec: asdbv1.RackPodSpec{
+			SchedulingPolicy: asdbv1.SchedulingPolicy{Tolerations: rackTolerations},
+		}},
+		{ID: 2, Size: 1},
+	}
+
+	rackStates := cluster.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		switch rackState.Rack.ID {
+		case 1:
+			if len(rackState.Rack.PodSpec.Tolerations) != 1 || rackState.Rack.PodSpec.Tolerations[0].Key != "rackKey" {
+				t.Errorf("rack 1 expected rack-level toleration override, got %v", rackState.Rack.PodSpec.Tolerations)
+			}
+		case 2:
+			if len(rackState.Rack.PodSpec.Tolerations) != 0 {
+				t.Errorf("rack 2 expected no tolerations override, got %v", rackState.Rack.PodSpec.Tolerations)
+			}
+		}
+	}
+}
+
+func TestNodeSelectorWithoutRackOverride(t *testing.T) {
+	// cluster-level nodeSelector set, no rack override
+	aeroCluster := &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 2}
+	aeroCluster.Spec.PodSpec.NodeSelector = map[string]string{"disktype": "ssd"}
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	aeroCluster.Spec.RackConfig.Racks = []asdbv1.Rack{
+		{ID: 1, Size: 1},
+		{ID: 2, Size: 1},
+	}
+
+	rackStates := cluster.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		if len(rackState.Rack.PodSpec.NodeSelector) != 0 {
+			t.Errorf("rack %d should have empty PodSpec.NodeSelector when no rack override is set", rackState.Rack.ID)
+		}
+	}
+}
+
+func TestNodeSelectorWithRackOverride(t *testing.T) {
+	// cluster-level nodeSelector set, rack 1 overrides via effective PodSpec
+	aeroCluster := &asdbv1.AerospikeCluster{}
+	aeroCluster.Spec = asdbv1.AerospikeClusterSpec{Size: 2}
+	aeroCluster.Spec.PodSpec.NodeSelector = map[string]string{"disktype": "ssd"}
+	aeroCluster.Spec.RackConfig = asdbv1.RackConfig{}
+	aeroCluster.Spec.RackConfig.Racks = []asdbv1.Rack{
+		{ID: 1, Size: 1, PodSpec: asdbv1.RackPodSpec{
+			SchedulingPolicy: asdbv1.SchedulingPolicy{NodeSelector: map[string]string{"disktype": "hdd"}},
+		}},
+		{ID: 2, Size: 1},
+	}
+
+	rackStates := cluster.GetConfiguredRackStateList(aeroCluster)
+	for _, rackState := range rackStates {
+		switch rackState.Rack.ID {
+		case 1:
+			if rackState.Rack.PodSpec.NodeSelector["disktype"] != "hdd" {
+				t.Errorf("rack 1 expected rack-level nodeSelector override 'hdd', got %v",
+					rackState.Rack.PodSpec.NodeSelector)
+			}
+		case 2:
+			if len(rackState.Rack.PodSpec.NodeSelector) != 0 {
+				t.Errorf("rack 2 expected no nodeSelector override, got %v", rackState.Rack.PodSpec.NodeSelector)
+			}
+		}
+	}
+}


### PR DESCRIPTION
When updating the affinity, tolerations or node selector on cluster level, the operator doesn't take it into account and doesn't roll restart the cluster automatically.

This change will update the Rack configurations accordingly to roll restart the cluster once a change is detected.