### PR TITLE
feat: allow configuring service account for aerospike pods

### DIFF
--- a/api/v1/aerospikecluster_types.go
+++ b/api/v1/aerospikecluster_types.go
@@ -392,6 +392,14 @@ type AerospikePodSpec struct { //nolint:govet // for readability
 	// More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
 	// +optional
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+
+	// ServiceAccountName is the name of the ServiceAccount used to run the aerospike pods.
+	// The ServiceAccount must exist in the cluster namespace and must be bound to a Role/ClusterRole
+	// granting at least the permissions of the default `aerospike-cluster` ClusterRole created by the
+	// operator's Helm chart.
+	// Defaults to "aerospike-operator-controller-manager" if not provided.
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 type AerospikeContainerSpec struct {

--- a/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml
+++ b/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml
@@ -3691,6 +3691,14 @@ spec:
                             type: string
                         type: object
                     type: object
+                  serviceAccountName:
+                    description: |-
+                      ServiceAccountName is the name of the ServiceAccount used to run the aerospike pods.
+                      The ServiceAccount must exist in the cluster namespace and must be bound to a Role/ClusterRole
+                      granting at least the permissions of the default `aerospike-cluster` ClusterRole created by the
+                      operator's Helm chart.
+                      Defaults to "aerospike-operator-controller-manager" if not provided.
+                    type: string
                   sidecars:
                     description: Sidecars to add to the pod.
                     items:
@@ -12873,6 +12881,14 @@ spec:
                             type: string
                         type: object
                     type: object
+                  serviceAccountName:
+                    description: |-
+                      ServiceAccountName is the name of the ServiceAccount used to run the aerospike pods.
+                      The ServiceAccount must exist in the cluster namespace and must be bound to a Role/ClusterRole
+                      granting at least the permissions of the default `aerospike-cluster` ClusterRole created by the
+                      operator's Helm chart.
+                      Defaults to "aerospike-operator-controller-manager" if not provided.
+                    type: string
                   sidecars:
                     description: Sidecars to add to the pod.
                     items:

--- a/helm-charts/aerospike-kubernetes-operator/crds/customresourcedefinition_aerospikeclusters.asdb.aerospike.com.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/crds/customresourcedefinition_aerospikeclusters.asdb.aerospike.com.yaml
@@ -3691,6 +3691,14 @@ spec:
                             type: string
                         type: object
                     type: object
+                  serviceAccountName:
+                    description: |-
+                      ServiceAccountName is the name of the ServiceAccount used to run the aerospike pods.
+                      The ServiceAccount must exist in the cluster namespace and must be bound to a Role/ClusterRole
+                      granting at least the permissions of the default `aerospike-cluster` ClusterRole created by the
+                      operator's Helm chart.
+                      Defaults to "aerospike-operator-controller-manager" if not provided.
+                    type: string
                   sidecars:
                     description: Sidecars to add to the pod.
                     items:
@@ -12873,6 +12881,14 @@ spec:
                             type: string
                         type: object
                     type: object
+                  serviceAccountName:
+                    description: |-
+                      ServiceAccountName is the name of the ServiceAccount used to run the aerospike pods.
+                      The ServiceAccount must exist in the cluster namespace and must be bound to a Role/ClusterRole
+                      granting at least the permissions of the default `aerospike-cluster` ClusterRole created by the
+                      operator's Helm chart.
+                      Defaults to "aerospike-operator-controller-manager" if not provided.
+                    type: string
                   sidecars:
                     description: Sidecars to add to the pod.
                     items:

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospikecluster-clusterrolebinding.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospikecluster-clusterrolebinding.yaml
@@ -16,3 +16,10 @@ subjects:
   name: aerospike-operator-controller-manager
   namespace: {{ $ns }}
 {{- end }}
+{{- with .Values.aerospikeCluster.serviceAccount }}
+{{- if .name }}
+- kind: ServiceAccount
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+{{- end }}
+{{- end }}

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospikecluster-serviceaccount.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospikecluster-serviceaccount.yaml
@@ -16,5 +16,26 @@ imagePullSecrets:
   - name: {{ . }}
   {{- end }}
 {{- end }}
+---
+{{- end }}
+{{- with .Values.aerospikeCluster.serviceAccount }}
+{{- if and .name (ne .create false) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+  labels:
+    app: {{ include "aerospike-kubernetes-operator.fullname" $ }}
+    chart: {{ $.Chart.Name }}
+    release: {{ $.Release.Name }}
+{{- with $.Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- range . }}
+  - name: {{ . }}
+  {{- end }}
+{{- end }}
+---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/aerospike-kubernetes-operator/values.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/values.yaml
@@ -18,6 +18,19 @@ rbac:
   create: true
   # serviceAccountName: "default"
 
+## AerospikeCluster ServiceAccount configuration.
+## In addition to the default `aerospike-operator-controller-manager` ServiceAccount
+## (created in each namespace in `watchNamespaces`), users can declare a single
+## extra ServiceAccount. When set, it is added as a subject of the existing
+## aerospike-cluster ClusterRoleBinding so it inherits the aerospike-cluster
+## ClusterRole permissions. Use its name with `spec.podSpec.serviceAccountName`
+## on an AerospikeCluster resource.
+aerospikeCluster:
+  serviceAccount: {}
+  #  name: my-aerospike-sa
+  #  namespace: aerospike
+  #  create: true   # If false, the ServiceAccount is assumed to already exist and only the binding is added.
+
 ## Ports
 healthPort: 8081
 metricsPort: 8443

--- a/internal/controller/cluster/configmap_test.go
+++ b/internal/controller/cluster/configmap_test.go
@@ -119,6 +119,27 @@ func TestPodSpecHash_ClusterNodeSelectorChange(t *testing.T) {
 	}
 }
 
+func TestPodSpecHash_ClusterServiceAccountChange(t *testing.T) {
+	rack := &asdbv1.Rack{ID: 1}
+
+	clusterBefore := newCluster(nil, nil, nil)
+	hashBefore, err := computePodSpecHash(clusterBefore, rack)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clusterAfter := newCluster(nil, nil, nil)
+	clusterAfter.Spec.PodSpec.ServiceAccountName = "custom-aerospike-sa"
+	hashAfter, err := computePodSpecHash(clusterAfter, rack)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hashBefore == hashAfter {
+		t.Fatal("expected hash to change when cluster-level serviceAccountName is set, but it didn't")
+	}
+}
+
 func TestPodSpecHash_NoChangeWhenNothingChanges(t *testing.T) {
 	rack := &asdbv1.Rack{ID: 1}
 

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -31,6 +31,7 @@ import (
 const (
 	// aerospike-operator- is the prefix set in config/default/kustomization.yaml file.
 	// Need to modify this name if prefix is changed in yaml file
+	// This is also the default ServiceAccount used when Spec.PodSpec.ServiceAccountName is unset.
 	aeroClusterServiceAccountName string = "aerospike-operator-controller-manager"
 
 	// This storage path annotation is added in pvc to make reverse association with storage.volume.path
@@ -143,7 +144,7 @@ func (r *SingleClusterReconciler) createSTS(
 					Labels: operatorDefinedLabels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: aeroClusterServiceAccountName,
+					ServiceAccountName: getServiceAccountName(r.aeroCluster),
 					// TerminationGracePeriodSeconds: &int64(30),
 					InitContainers: []corev1.Container{
 						{
@@ -1021,6 +1022,7 @@ func (r *SingleClusterReconciler) updateSTSFromPodSpec(
 
 	st.Spec.Template.Spec.SecurityContext = r.aeroCluster.Spec.PodSpec.SecurityContext
 	st.Spec.Template.Spec.ImagePullSecrets = r.aeroCluster.Spec.PodSpec.ImagePullSecrets
+	st.Spec.Template.Spec.ServiceAccountName = getServiceAccountName(r.aeroCluster)
 
 	st.Spec.Template.Spec.Containers =
 		updateSTSContainers(
@@ -1649,6 +1651,14 @@ func newSTSEnvVarStatic(name, value string) corev1.EnvVar {
 		Name:  name,
 		Value: value,
 	}
+}
+
+func getServiceAccountName(aeroCluster *asdbv1.AerospikeCluster) string {
+	if aeroCluster.Spec.PodSpec.ServiceAccountName != "" {
+		return aeroCluster.Spec.PodSpec.ServiceAccountName
+	}
+
+	return aeroClusterServiceAccountName
 }
 
 // Return if volume with name given is present in volumes array else return nil.

--- a/internal/webhook/v1/aerospikecluster_validating_webhook.go
+++ b/internal/webhook/v1/aerospikecluster_validating_webhook.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -1260,6 +1261,12 @@ func isFileStorageConfiguredForDir(fileStorageList []string, dir string) bool {
 func validatePodSpec(cluster *asdbv1.AerospikeCluster) error {
 	if cluster.Spec.PodSpec.HostNetwork && asdbv1.GetBool(cluster.Spec.PodSpec.MultiPodPerHost) {
 		return fmt.Errorf("host networking cannot be enabled with multi pod per host")
+	}
+
+	if name := cluster.Spec.PodSpec.ServiceAccountName; name != "" {
+		if errs := k8svalidation.IsDNS1123Subdomain(name); len(errs) > 0 {
+			return fmt.Errorf("invalid serviceAccountName %q: %s", name, strings.Join(errs, ", "))
+		}
 	}
 
 	if err := validateDNS(cluster.Spec.PodSpec.DNSPolicy, cluster.Spec.PodSpec.DNSConfig); err != nil {


### PR DESCRIPTION
Add Spec.PodSpec.ServiceAccountName to AerospikeCluster so users can run aerospike pods under a user-supplied ServiceAccount instead of the hardcoded aerospike-operator-controller-manager. The field is optional
and falls back to the previous default, keeping existing clusters unchanged. Changes to the field flow through updateSTSFromPodSpec and are included in the podSpec hash, so flipping it triggers a rolling restart; this is covered by the new TestPodSpecHash_ClusterServiceAccountChange unit test.

The helm chart gains aerospikeCluster.serviceAccount so operators can declare a single extra ServiceAccount at install time; when set it is created (unless create: false) and appended as a subject of the existing aerospike-cluster ClusterRoleBinding, so it inherits the operator-managed permissions. This mirrors the CR shape, which also accepts a single ServiceAccount name.