### PR TITLE
feat: add and remove persistent volumes on a running Aerospike cluster

### DIFF
--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -143,6 +143,23 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 		found := &appsv1.StatefulSet{}
 		stsName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster, state.Rack.ID)
 
+		// If a previous in-place STS replace was interrupted, the rack's pods and
+		// PVCs are still alive and orphaned; recreate the STS sized to re-adopt
+		// them. Otherwise fall through to the unchanged get/create-empty path.
+		var recovered *appsv1.StatefulSet
+		if recovered, res = r.recoverInterruptedStsReplacement(state); !res.IsSuccess {
+			return res
+		}
+		if recovered != nil {
+			// Recovered != nil means "We were able to recreate the STS".
+			//   . So we return ReconcileRequeue for the next reconciliation loop to find the created STS
+			//   . And continue the rack reconciliation as expected.
+			//   . NB: the subsequent r.Client.Get below may return NotFound (cache lag),
+			//     triggering a code path we shouldn't execute.
+			//   . Hence the ReconcileRequeue to delay the continuation of Rack reconciliation.
+			return common.ReconcileRequeueAfter(1)
+		}
+
 		if err = r.Client.Get(context.TODO(), stsName, found); err != nil {
 			if !errors.IsNotFound(err) {
 				return common.ReconcileError(err)
@@ -203,6 +220,23 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 		found := &appsv1.StatefulSet{}
 		stsName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster, state.Rack.ID)
 
+		// If a previous in-place STS replace was interrupted, the rack's pods and
+		// PVCs are still alive and orphaned; recreate the STS sized to re-adopt
+		// them. Otherwise fall through to the unchanged get/create-empty path.
+		var recovered *appsv1.StatefulSet
+		if recovered, res = r.recoverInterruptedStsReplacement(state); !res.IsSuccess {
+			return res
+		}
+		if recovered != nil {
+			// Recovered != nil means "We were able to recreate the STS".
+			//   . So we return ReconcileRequeue for the next reconciliation loop to find the created STS
+			//   . And continue the rack reconciliation as expected.
+			//   . NB: the subsequent r.Client.Get below may return NotFound (cache lag),
+			//     triggering a code path we shouldn't execute.
+			//   . Hence the ReconcileRequeue to delay the continuation of Rack reconciliation.
+			return common.ReconcileRequeueAfter(1)
+		}
+
 		if err := r.Client.Get(context.TODO(), stsName, found); err != nil {
 			if !errors.IsNotFound(err) {
 				return common.ReconcileError(err)
@@ -238,6 +272,141 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 	return common.ReconcileSuccess()
 }
 
+// recoverInterruptedStsReplacement handles the case where a rack's StatefulSet is
+// missing because an in-place STS replace was interrupted (replaceSTS
+// orphan-deletes the STS, then a crash/eviction/leader change happens before
+// createSTS recreates it). In that situation the rack's pods and PVCs are still
+// alive and orphaned; recreating the STS at size 0 (the normal new-rack path)
+// would make the scale-up path treat them as dangling and cascade-delete their
+// PVCs (data loss).
+//
+// It fetches the rack's StatefulSet itself so it can be called as a self-contained
+// pre-step that leaves the caller's existing get/create-empty path untouched. If
+// the STS is present, or it is missing but no pods exist for the rack in status
+// (a brand-new rack), it returns (nil, success) so the caller proceeds normally.
+//
+// The interrupted-replace case is distinguished from a brand-new rack using the
+// cluster's pod status (status.pods), the operator's authoritative, durable
+// record of pods that should exist: an entry is added when a pod is initialized
+// and removed only when the operator intentionally removes a pod
+// (scale-down/rack-delete). It survives operator crashes and CR re-delivery
+// (status is a subresource untouched by kubectl apply).
+//
+// If the STS is missing and status.pods has entries for this rack, the STS is
+// recreated sized to re-adopt the orphans (max(desired size, highest status pod
+// ordinal + 1)) and the recreated StatefulSet is returned.
+func (r *SingleClusterReconciler) recoverInterruptedStsReplacement(state *RackState) (
+	*appsv1.StatefulSet, common.ReconcileResult,
+) {
+	found := &appsv1.StatefulSet{}
+	stsName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster, state.Rack.ID)
+
+	if err := r.Client.Get(context.TODO(), stsName, found); err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, common.ReconcileError(err)
+		}
+
+		// STS is missing: distinguish a brand-new rack from an interrupted replace.
+		size, hasExistingPods, sizeErr := r.replaceRecoverySize(state.Rack.ID, state.Size)
+		if sizeErr != nil {
+			return nil, common.ReconcileError(sizeErr)
+		}
+
+		if hasExistingPods {
+			// Interrupted replace (or any abnormal STS loss on a live rack):
+			// recreate the STS sized to re-adopt the orphaned pods rather than
+			// treating them as dangling. Any size delta versus the desired spec
+			// is handled by the normal scale up/down path on subsequent reconciles.
+			return r.createRecoveringRack(&RackState{Rack: state.Rack, Size: size})
+		}
+	}
+
+	// STS present, or a brand-new rack: nothing to recover, let the caller proceed.
+	return nil, common.ReconcileSuccess()
+}
+
+// createRecoveringRack recreates the StatefulSet of a rack whose pods and PVCs
+// are still alive but whose StatefulSet is missing (an interrupted in-place
+// replace, see replaceSTS / recoverInterruptedStsReplacement). It ensures the rack ConfigMap
+// exists first (buildSTSConfigMap is idempotent, in case the interrupted
+// reconcile never created it and the pods must mount it) and recreates the STS at
+// rackState.Size so it re-adopts the orphaned pods.
+//
+// Unlike createEmptyRack, it deliberately does NOT delete the STS on failure:
+// createSTS returns a non-nil STS when it is created but its pods are not ready
+// within the wait timeout, and deleting it would cascade-delete the very orphan
+// pods we are trying to preserve (and loop). Like replaceSTS, a
+// created-but-not-yet-ready STS is left in place for the next reconcile to await.
+func (r *SingleClusterReconciler) createRecoveringRack(rackState *RackState) (
+	*appsv1.StatefulSet, common.ReconcileResult,
+) {
+	r.Log.Info(
+		"Recovering interrupted StatefulSet replace: recreating sized to re-adopt orphaned pods",
+		"rackID", rackState.Rack.ID, "recoverySize", rackState.Size,
+	)
+
+	name := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster, rackState.Rack.ID)
+	if err := r.buildSTSConfigMap(name, rackState.Rack); err != nil {
+		return nil, common.ReconcileError(
+			fmt.Errorf("failed to build configmap for replace recovery: %v", err),
+		)
+	}
+
+	found, err := r.createSTS(name, rackState)
+	if err != nil {
+		return found, common.ReconcileError(
+			fmt.Errorf("failed to recreate statefulset for replace recovery: %v", err),
+		)
+	}
+
+	r.Recorder.Eventf(
+		r.aeroCluster, corev1.EventTypeNormal, "ReplaceRecovered",
+		"[rack-%d] Recovered interrupted StatefulSet replace; recreated sized to re-adopt orphaned pods (size: %d)",
+		rackState.Rack.ID, rackState.Size,
+	)
+
+	return found, common.ReconcileSuccess()
+}
+
+// replaceRecoverySize inspects the cluster pod status (status.pods) to decide how
+// to recreate a rack whose StatefulSet is missing. It returns whether the rack
+// already had pods (i.e. it is not a brand-new rack) and, when it did, the size
+// needed to re-adopt every orphaned pod: max(desiredSize, highest status pod
+// ordinal + 1). It returns an error if a pod name in status cannot be parsed.
+func (r *SingleClusterReconciler) replaceRecoverySize(rackID int, desiredSize int32) (
+	size int32, hasExistingPods bool, err error,
+) {
+	size = desiredSize
+
+	for podName := range r.aeroCluster.Status.Pods {
+		podRackID, rerr := utils.GetRackIDFromPodName(podName)
+		if rerr != nil {
+			return 0, false, fmt.Errorf(
+				"failed to get rackID from pod name %q for replace recovery: %v", podName, rerr,
+			)
+		}
+
+		if *podRackID != rackID {
+			continue
+		}
+
+		hasExistingPods = true
+
+		ordinal, oerr := getSTSPodOrdinal(podName)
+		if oerr != nil {
+			return 0, false, fmt.Errorf(
+				"failed to get ordinal from pod name %q for replace recovery: %v", podName, oerr,
+			)
+		}
+
+		if *ordinal+1 > size {
+			size = *ordinal + 1
+		}
+	}
+
+	return size, hasExistingPods, nil
+}
+
 func (r *SingleClusterReconciler) createEmptyRack(rackState *RackState) (
 	*appsv1.StatefulSet, common.ReconcileResult,
 ) {
@@ -257,6 +426,11 @@ func (r *SingleClusterReconciler) createEmptyRack(rackState *RackState) (
 
 	found, err := r.createSTS(stsName, rackState)
 	if err != nil {
+		// If by any "cache" the resource was not found before but now do exists, we cannot take the risk of a deletion
+		// It may happen in the case of recovering a STS during a change of volumeClaimTemplate.
+		if errors.IsAlreadyExists(err) {
+			return nil, common.ReconcileError(err)
+		}
 		r.Log.Error(
 			err, "Statefulset setup failed. Deleting statefulset", "name",
 			stsName, "err", err,

--- a/internal/controller/cluster/rack_test.go
+++ b/internal/controller/cluster/rack_test.go
@@ -1,0 +1,117 @@
+package cluster
+
+import (
+	"testing"
+
+	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
+)
+
+// statusPods builds a status.pods map from the given pod names.
+func statusPods(names ...string) map[string]asdbv1.AerospikePodStatus {
+	pods := make(map[string]asdbv1.AerospikePodStatus, len(names))
+	for _, name := range names {
+		pods[name] = asdbv1.AerospikePodStatus{}
+	}
+
+	return pods
+}
+
+// TestReplaceRecoverySize covers the data-safety-critical sizing used to recreate
+// a rack whose StatefulSet is missing: a new rack must not "recover", and an
+// existing rack must be sized to re-adopt every orphaned pod (never smaller than
+// the highest live ordinal, so no orphan is treated as dangling).
+func TestReplaceRecoverySize(t *testing.T) {
+	const rackID = 11
+
+	testCases := []struct {
+		name         string
+		statusPods   map[string]asdbv1.AerospikePodStatus
+		desiredSize  int32
+		wantSize     int32
+		wantExisting bool
+		wantErr      bool
+	}{
+		{
+			name:         "no status pods is a brand-new rack",
+			statusPods:   statusPods(),
+			desiredSize:  3,
+			wantSize:     3,
+			wantExisting: false,
+		},
+		{
+			name:         "pods only on other racks are ignored (new rack)",
+			statusPods:   statusPods("aerospikes99-p02-10-0", "aerospikes99-p02-10-1"),
+			desiredSize:  2,
+			wantSize:     2,
+			wantExisting: false,
+		},
+		{
+			name:         "contiguous pods size to desired",
+			statusPods:   statusPods("aerospikes99-p02-11-0", "aerospikes99-p02-11-1", "aerospikes99-p02-11-2"),
+			desiredSize:  3,
+			wantSize:     3,
+			wantExisting: true,
+		},
+		{
+			name:         "highest ordinal beyond desired grows the size to re-adopt all orphans",
+			statusPods:   statusPods("aerospikes99-p02-11-0", "aerospikes99-p02-11-4"),
+			desiredSize:  2,
+			wantSize:     5,
+			wantExisting: true,
+		},
+		{
+			name:         "desired larger than ordinals is kept",
+			statusPods:   statusPods("aerospikes99-p02-11-0"),
+			desiredSize:  4,
+			wantSize:     4,
+			wantExisting: true,
+		},
+		{
+			name: "only the target rack's pods affect the size",
+			statusPods: statusPods(
+				"aerospikes99-p02-11-0", "aerospikes99-p02-11-1", "aerospikes99-p02-12-9",
+			),
+			desiredSize:  1,
+			wantSize:     2,
+			wantExisting: true,
+		},
+		{
+			name:        "unparseable pod name errors",
+			statusPods:  statusPods("badname"),
+			desiredSize: 1,
+			wantErr:     true,
+		},
+	}
+
+	for idx := range testCases {
+		tc := testCases[idx]
+		t.Run(tc.name, func(t *testing.T) {
+			r := &SingleClusterReconciler{
+				aeroCluster: &asdbv1.AerospikeCluster{},
+			}
+			r.aeroCluster.Status.Pods = tc.statusPods
+
+			size, existing, err := r.replaceRecoverySize(rackID, tc.desiredSize)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("replaceRecoverySize() expected an error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("replaceRecoverySize() unexpected error: %v", err)
+			}
+
+			if existing != tc.wantExisting {
+				t.Errorf("hasExistingPods = %v, want %v", existing, tc.wantExisting)
+			}
+
+			if size != tc.wantSize {
+				t.Errorf("size = %d, want %d", size, tc.wantSize)
+			}
+		})
+	}
+}

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -665,7 +665,7 @@ func (r *SingleClusterReconciler) updateSTS(
 	// the orphan-delete + recreate path (the pods keep running while the
 	// StatefulSet is recreated with the new templates). Otherwise we fall back to
 	// the normal in-place update.
-	if volumeClaimTemplatesChanged(found, statefulSet) {
+	if volumeClaimTemplatesChanged(found, rackState) {
 		r.Log.Info(
 			"VolumeClaimTemplates changed, recreating StatefulSet with orphaned pods",
 			"statefulSet", statefulSet.Name,
@@ -714,18 +714,25 @@ func (r *SingleClusterReconciler) updateSTS(
 }
 
 // volumeClaimTemplatesChanged reports whether the set of VolumeClaimTemplate names
-// differs between the existing and the desired StatefulSet (i.e. a template was
-// added or removed). Such a change is immutable on a StatefulSet and requires
-// delete+recreate rather than an in-place update.
-func volumeClaimTemplatesChanged(found, desired *appsv1.StatefulSet) bool {
+// differs between the existing StatefulSet and the desired storage spec (i.e. a
+// PV-backed volume was added or removed). Such a change is immutable on a
+// StatefulSet and requires delete+recreate rather than an in-place update.
+//
+// The desired names are derived from the rack storage spec rather than from the
+// in-memory StatefulSet, because updateSTSPVStorage only ever appends
+// VolumeClaimTemplates to the existing StatefulSet (it never prunes removed
+// ones), so a removal would otherwise be invisible.
+func volumeClaimTemplatesChanged(found *appsv1.StatefulSet, rackState *RackState) bool {
 	foundNames := make(sets.Set[string], len(found.Spec.VolumeClaimTemplates))
 	for idx := range found.Spec.VolumeClaimTemplates {
 		foundNames.Insert(found.Spec.VolumeClaimTemplates[idx].Name)
 	}
 
-	desiredNames := make(sets.Set[string], len(desired.Spec.VolumeClaimTemplates))
-	for idx := range desired.Spec.VolumeClaimTemplates {
-		desiredNames.Insert(desired.Spec.VolumeClaimTemplates[idx].Name)
+	desiredVolumes := webhookv1.GetPVsVolumesFromStorage(&rackState.Rack.Storage)
+	desiredNames := make(sets.Set[string], len(desiredVolumes))
+
+	for idx := range desiredVolumes {
+		desiredNames.Insert(desiredVolumes[idx].Name)
 	}
 
 	return !foundNames.Equal(desiredNames)

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -655,6 +655,40 @@ func (r *SingleClusterReconciler) updateSTS(
 	// TODO: Add validation. device, file, both should not exist in same storage class
 	r.updateSTSStorage(statefulSet, rackState)
 
+	found, err := r.getSTS(rackState)
+	if err != nil {
+		return fmt.Errorf("failed to get existing StatefulSet %s: %v", statefulSet.Name, err)
+	}
+
+	// StatefulSet VolumeClaimTemplates are immutable, so a plain Update() cannot
+	// add volume claim templates. Only when such a change is detected do we take
+	// the orphan-delete + recreate path (the pods keep running while the
+	// StatefulSet is recreated with the new templates). Otherwise we fall back to
+	// the normal in-place update.
+	if volumeClaimTemplatesChanged(found, statefulSet) {
+		r.Log.Info(
+			"VolumeClaimTemplates changed, recreating StatefulSet with orphaned pods",
+			"statefulSet", statefulSet.Name,
+		)
+
+		newSTS, err := r.replaceSTS(found, rackState)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to replace StatefulSet %s: %v",
+				statefulSet.Name,
+				err,
+			)
+		}
+
+		*statefulSet = *newSTS
+
+		r.Log.V(1).Info(
+			"Saved StatefulSet", "statefulSet", *statefulSet,
+		)
+
+		return nil
+	}
+
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		found, err := r.getSTS(rackState)
 		if err != nil {
@@ -677,6 +711,94 @@ func (r *SingleClusterReconciler) updateSTS(
 	)
 
 	return nil
+}
+
+// volumeClaimTemplatesChanged reports whether the set of VolumeClaimTemplate names
+// differs between the existing and the desired StatefulSet (i.e. a template was
+// added or removed). Such a change is immutable on a StatefulSet and requires
+// delete+recreate rather than an in-place update.
+func volumeClaimTemplatesChanged(found, desired *appsv1.StatefulSet) bool {
+	foundNames := make(sets.Set[string], len(found.Spec.VolumeClaimTemplates))
+	for idx := range found.Spec.VolumeClaimTemplates {
+		foundNames.Insert(found.Spec.VolumeClaimTemplates[idx].Name)
+	}
+
+	desiredNames := make(sets.Set[string], len(desired.Spec.VolumeClaimTemplates))
+	for idx := range desired.Spec.VolumeClaimTemplates {
+		desiredNames.Insert(desired.Spec.VolumeClaimTemplates[idx].Name)
+	}
+
+	return !foundNames.Equal(desiredNames)
+}
+
+// replaceSTS deletes the existing StatefulSet with an orphan propagation policy
+// (preserving its pods and PVCs) and recreates it from scratch via createSTS.
+// This is required to amend the (otherwise immutable) VolumeClaimTemplates of a
+// live StatefulSet without disrupting the running pods.
+//
+// The AerospikeCluster CR is the single source of truth for the StatefulSet spec
+// and metadata, so createSTS reproduces the desired object faithfully (including
+// the new VolumeClaimTemplates) and re-adopts the orphaned pods, waiting for them
+// to become ready.
+func (r *SingleClusterReconciler) replaceSTS(
+	found *appsv1.StatefulSet, rackState *RackState,
+) (*appsv1.StatefulSet, error) {
+	const (
+		deleteWaitMaxRetry = 30
+		deleteWaitInterval = time.Second * 2
+	)
+
+	// Delete the existing STS but orphan its pods (and PVCs) so they keep running.
+	orphan := metav1.DeletePropagationOrphan
+
+	r.Log.Info(
+		"Deleting StatefulSet with orphan propagation to recreate it",
+		"namespace", found.Namespace, "name", found.Name,
+	)
+
+	if err := r.Client.Delete(
+		context.TODO(), found, client.PropagationPolicy(orphan),
+	); err != nil && !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to orphan-delete StatefulSet: %v", err)
+	}
+
+	// Wait until the old STS object is fully gone before recreating with the same name.
+	namespacedName := types.NamespacedName{
+		Namespace: found.Namespace,
+		Name:      found.Name,
+	}
+
+	for i := 0; i < deleteWaitMaxRetry; i++ {
+		tmp := &appsv1.StatefulSet{}
+		getErr := r.Client.Get(context.TODO(), namespacedName, tmp)
+
+		if errors.IsNotFound(getErr) {
+			break
+		}
+
+		if getErr != nil {
+			return nil, fmt.Errorf("failed waiting for StatefulSet deletion: %v", getErr)
+		}
+
+		if i == deleteWaitMaxRetry-1 {
+			return nil, fmt.Errorf("timed out waiting for StatefulSet %s to be deleted", found.Name)
+		}
+
+		time.Sleep(deleteWaitInterval)
+	}
+
+	// Recreate the StatefulSet from scratch via the canonical builder.
+	newSTS, err := r.createSTS(namespacedName, rackState)
+	if err != nil {
+		return nil, fmt.Errorf("failed to recreate StatefulSet: %v", err)
+	}
+
+	r.Log.Info(
+		"Recreated StatefulSet (pods orphaned and re-adopted)",
+		"namespace", newSTS.Namespace, "name", newSTS.Name,
+	)
+
+	return newSTS, nil
 }
 
 // Returns external storage devices and the corresponding source

--- a/internal/controller/cluster/statefulset_test.go
+++ b/internal/controller/cluster/statefulset_test.go
@@ -1,0 +1,87 @@
+package cluster
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func stsWithVCTs(templates ...corev1.PersistentVolumeClaim) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: templates,
+		},
+	}
+}
+
+func vct(name, size string) corev1.PersistentVolumeClaim {
+	return corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse(size),
+				},
+			},
+		},
+	}
+}
+
+func TestVolumeClaimTemplatesChanged(t *testing.T) {
+	testCases := []struct {
+		found    *appsv1.StatefulSet
+		desired  *appsv1.StatefulSet
+		name     string
+		expected bool
+	}{
+		{
+			name:     "adding a volume claim template is detected",
+			found:    stsWithVCTs(vct("data", "10Gi")),
+			desired:  stsWithVCTs(vct("data", "10Gi"), vct("data2", "10Gi")),
+			expected: true,
+		},
+		{
+			name:     "removing a volume claim template is detected",
+			found:    stsWithVCTs(vct("data", "10Gi"), vct("data2", "10Gi")),
+			desired:  stsWithVCTs(vct("data", "10Gi")),
+			expected: true,
+		},
+		{
+			name:     "resizing an existing template (same name) is NOT detected by name-set comparison",
+			found:    stsWithVCTs(vct("data", "10Gi")),
+			desired:  stsWithVCTs(vct("data", "20Gi")),
+			expected: false,
+		},
+		{
+			name:     "no change yields false",
+			found:    stsWithVCTs(vct("data", "10Gi"), vct("data2", "10Gi")),
+			desired:  stsWithVCTs(vct("data", "10Gi"), vct("data2", "10Gi")),
+			expected: false,
+		},
+		{
+			name:     "same names in different order yields false",
+			found:    stsWithVCTs(vct("data", "10Gi"), vct("data2", "10Gi")),
+			desired:  stsWithVCTs(vct("data2", "10Gi"), vct("data", "10Gi")),
+			expected: false,
+		},
+		{
+			name:     "no templates on either side yields false",
+			found:    stsWithVCTs(),
+			desired:  stsWithVCTs(),
+			expected: false,
+		},
+	}
+
+	for idx := range testCases {
+		tc := testCases[idx]
+		t.Run(tc.name, func(t *testing.T) {
+			got := volumeClaimTemplatesChanged(tc.found, tc.desired)
+			if got != tc.expected {
+				t.Fatalf("volumeClaimTemplatesChanged = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/controller/cluster/statefulset_test.go
+++ b/internal/controller/cluster/statefulset_test.go
@@ -5,11 +5,19 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
 )
 
-func stsWithVCTs(templates ...corev1.PersistentVolumeClaim) *appsv1.StatefulSet {
+func stsWithVCTs(names ...string) *appsv1.StatefulSet {
+	templates := make([]corev1.PersistentVolumeClaim, 0, len(names))
+	for _, name := range names {
+		templates = append(templates, corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		})
+	}
+
 	return &appsv1.StatefulSet{
 		Spec: appsv1.StatefulSetSpec{
 			VolumeClaimTemplates: templates,
@@ -17,68 +25,86 @@ func stsWithVCTs(templates ...corev1.PersistentVolumeClaim) *appsv1.StatefulSet 
 	}
 }
 
-func vct(name, size string) corev1.PersistentVolumeClaim {
-	return corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			Resources: corev1.VolumeResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse(size),
-				},
+// rackStateWithPVs builds a RackState whose storage spec contains one PV-backed
+// volume per provided name (plus, when set, a single non-PV volume to ensure it
+// is ignored by the PV-name comparison).
+func rackStateWithPVs(pvNames []string, nonPVNames ...string) *RackState {
+	volumes := make([]asdbv1.VolumeSpec, 0, len(pvNames)+len(nonPVNames))
+
+	for _, name := range pvNames {
+		volumes = append(volumes, asdbv1.VolumeSpec{
+			Name: name,
+			Source: asdbv1.VolumeSource{
+				PersistentVolume: &asdbv1.PersistentVolumeSpec{},
 			},
+		})
+	}
+
+	for _, name := range nonPVNames {
+		volumes = append(volumes, asdbv1.VolumeSpec{
+			Name: name,
+			Source: asdbv1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		})
+	}
+
+	return &RackState{
+		Rack: &asdbv1.Rack{
+			Storage: asdbv1.AerospikeStorageSpec{Volumes: volumes},
 		},
 	}
 }
 
 func TestVolumeClaimTemplatesChanged(t *testing.T) {
 	testCases := []struct {
-		found    *appsv1.StatefulSet
-		desired  *appsv1.StatefulSet
-		name     string
-		expected bool
+		found     *appsv1.StatefulSet
+		rackState *RackState
+		name      string
+		expected  bool
 	}{
 		{
-			name:     "adding a volume claim template is detected",
-			found:    stsWithVCTs(vct("data", "10Gi")),
-			desired:  stsWithVCTs(vct("data", "10Gi"), vct("data2", "10Gi")),
-			expected: true,
+			name:      "adding a volume claim template is detected",
+			found:     stsWithVCTs("data"),
+			rackState: rackStateWithPVs([]string{"data", "data2"}),
+			expected:  true,
 		},
 		{
-			name:     "removing a volume claim template is detected",
-			found:    stsWithVCTs(vct("data", "10Gi"), vct("data2", "10Gi")),
-			desired:  stsWithVCTs(vct("data", "10Gi")),
-			expected: true,
+			name:      "removing a volume claim template is detected",
+			found:     stsWithVCTs("data", "data2"),
+			rackState: rackStateWithPVs([]string{"data"}),
+			expected:  true,
 		},
 		{
-			name:     "resizing an existing template (same name) is NOT detected by name-set comparison",
-			found:    stsWithVCTs(vct("data", "10Gi")),
-			desired:  stsWithVCTs(vct("data", "20Gi")),
-			expected: false,
+			name:      "no change yields false",
+			found:     stsWithVCTs("data", "data2"),
+			rackState: rackStateWithPVs([]string{"data", "data2"}),
+			expected:  false,
 		},
 		{
-			name:     "no change yields false",
-			found:    stsWithVCTs(vct("data", "10Gi"), vct("data2", "10Gi")),
-			desired:  stsWithVCTs(vct("data", "10Gi"), vct("data2", "10Gi")),
-			expected: false,
+			name:      "same names in different order yields false",
+			found:     stsWithVCTs("data", "data2"),
+			rackState: rackStateWithPVs([]string{"data2", "data"}),
+			expected:  false,
 		},
 		{
-			name:     "same names in different order yields false",
-			found:    stsWithVCTs(vct("data", "10Gi"), vct("data2", "10Gi")),
-			desired:  stsWithVCTs(vct("data2", "10Gi"), vct("data", "10Gi")),
-			expected: false,
+			name:      "non-PV volumes in the spec are ignored",
+			found:     stsWithVCTs("data"),
+			rackState: rackStateWithPVs([]string{"data"}, "confdir"),
+			expected:  false,
 		},
 		{
-			name:     "no templates on either side yields false",
-			found:    stsWithVCTs(),
-			desired:  stsWithVCTs(),
-			expected: false,
+			name:      "no templates and no PV volumes yields false",
+			found:     stsWithVCTs(),
+			rackState: rackStateWithPVs(nil),
+			expected:  false,
 		},
 	}
 
 	for idx := range testCases {
 		tc := testCases[idx]
 		t.Run(tc.name, func(t *testing.T) {
-			got := volumeClaimTemplatesChanged(tc.found, tc.desired)
+			got := volumeClaimTemplatesChanged(tc.found, tc.rackState)
 			if got != tc.expected {
 				t.Fatalf("volumeClaimTemplatesChanged = %v, want %v", got, tc.expected)
 			}

--- a/internal/webhook/v1/storage.go
+++ b/internal/webhook/v1/storage.go
@@ -77,14 +77,12 @@ func validateAddedOrRemovedVolumes(oldStorage, newStorage *asdbv1.AerospikeStora
 		}
 
 		if !matched {
-			// Removing a persistent volume stays blocked to guard against
-			// unintended volume (and data) deletion.
-			if oldVolume.Source.PersistentVolume != nil {
-				return []asdbv1.VolumeSpec{}, []asdbv1.VolumeSpec{}, fmt.Errorf(
-					"cannot remove persistent volume: %v", oldVolume,
-				)
-			}
-
+			// Removing a persistent volume is allowed: the corresponding
+			// StatefulSet VolumeClaimTemplate is dropped via an orphan-delete +
+			// recreate of the StatefulSet (templates are immutable on an
+			// existing StatefulSet). The detach happens on the rolling pod
+			// restart, so with RF>=2 the data migrates off before the next pod
+			// is cycled. The now-orphaned PVCs are intentionally left in place.
 			removedVolumes = append(removedVolumes, *oldVolume)
 		}
 	}

--- a/internal/webhook/v1/storage.go
+++ b/internal/webhook/v1/storage.go
@@ -57,12 +57,10 @@ func validateAddedOrRemovedVolumes(oldStorage, newStorage *asdbv1.AerospikeStora
 		}
 
 		if !matched {
-			if newVolume.Source.PersistentVolume != nil {
-				return []asdbv1.VolumeSpec{}, []asdbv1.VolumeSpec{}, fmt.Errorf(
-					"cannot add persistent volume: %v", newVolume,
-				)
-			}
-
+			// Adding a persistent volume is allowed: it maps to a new
+			// StatefulSet VolumeClaimTemplate, which the reconciler applies via
+			// an orphan-delete + recreate of the StatefulSet (templates are
+			// immutable on an existing StatefulSet).
 			addedVolumes = append(addedVolumes, *newVolume)
 		}
 	}
@@ -79,6 +77,8 @@ func validateAddedOrRemovedVolumes(oldStorage, newStorage *asdbv1.AerospikeStora
 		}
 
 		if !matched {
+			// Removing a persistent volume stays blocked to guard against
+			// unintended volume (and data) deletion.
 			if oldVolume.Source.PersistentVolume != nil {
 				return []asdbv1.VolumeSpec{}, []asdbv1.VolumeSpec{}, fmt.Errorf(
 					"cannot remove persistent volume: %v", oldVolume,

--- a/internal/webhook/v1/storage_test.go
+++ b/internal/webhook/v1/storage_test.go
@@ -60,10 +60,11 @@ func TestValidateAddedOrRemovedVolumes(t *testing.T) {
 			expectedAdded: []string{"data2"},
 		},
 		{
-			name:       "removing a persistent volume is blocked",
-			oldStorage: storageWith(pvVolume("data"), pvVolume("data2")),
-			newStorage: storageWith(pvVolume("data")),
-			expectErr:  true,
+			name:            "removing a persistent volume is allowed",
+			oldStorage:      storageWith(pvVolume("data"), pvVolume("data2")),
+			newStorage:      storageWith(pvVolume("data")),
+			expectErr:       false,
+			expectedRemoved: []string{"data2"},
 		},
 		{
 			name:            "adding and removing a config map volume is allowed",

--- a/internal/webhook/v1/storage_test.go
+++ b/internal/webhook/v1/storage_test.go
@@ -1,0 +1,124 @@
+package v1
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
+)
+
+func pvVolume(name string) asdbv1.VolumeSpec {
+	return asdbv1.VolumeSpec{
+		Name: name,
+		Source: asdbv1.VolumeSource{
+			PersistentVolume: &asdbv1.PersistentVolumeSpec{
+				StorageClass: "ssd",
+			},
+		},
+	}
+}
+
+func configMapVolume(name string) asdbv1.VolumeSpec {
+	return asdbv1.VolumeSpec{
+		Name: name,
+		Source: asdbv1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: name},
+			},
+		},
+	}
+}
+
+func storageWith(volumes ...asdbv1.VolumeSpec) *asdbv1.AerospikeStorageSpec {
+	return &asdbv1.AerospikeStorageSpec{Volumes: volumes}
+}
+
+func volumeNames(volumes []asdbv1.VolumeSpec) []string {
+	names := make([]string, 0, len(volumes))
+	for idx := range volumes {
+		names = append(names, volumes[idx].Name)
+	}
+
+	return names
+}
+
+func TestValidateAddedOrRemovedVolumes(t *testing.T) {
+	testCases := []struct {
+		oldStorage      *asdbv1.AerospikeStorageSpec
+		newStorage      *asdbv1.AerospikeStorageSpec
+		name            string
+		expectedAdded   []string
+		expectedRemoved []string
+		expectErr       bool
+	}{
+		{
+			name:          "adding a persistent volume is allowed",
+			oldStorage:    storageWith(pvVolume("data")),
+			newStorage:    storageWith(pvVolume("data"), pvVolume("data2")),
+			expectErr:     false,
+			expectedAdded: []string{"data2"},
+		},
+		{
+			name:       "removing a persistent volume is blocked",
+			oldStorage: storageWith(pvVolume("data"), pvVolume("data2")),
+			newStorage: storageWith(pvVolume("data")),
+			expectErr:  true,
+		},
+		{
+			name:            "adding and removing a config map volume is allowed",
+			oldStorage:      storageWith(pvVolume("data"), configMapVolume("cfg-old")),
+			newStorage:      storageWith(pvVolume("data"), configMapVolume("cfg-new")),
+			expectErr:       false,
+			expectedAdded:   []string{"cfg-new"},
+			expectedRemoved: []string{"cfg-old"},
+		},
+		{
+			name:       "no change yields no added or removed volumes",
+			oldStorage: storageWith(pvVolume("data")),
+			newStorage: storageWith(pvVolume("data")),
+			expectErr:  false,
+		},
+	}
+
+	for idx := range testCases {
+		tc := testCases[idx]
+		t.Run(tc.name, func(t *testing.T) {
+			added, removed, err := validateAddedOrRemovedVolumes(tc.oldStorage, tc.newStorage)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			assertSameNames(t, "added", tc.expectedAdded, volumeNames(added))
+			assertSameNames(t, "removed", tc.expectedRemoved, volumeNames(removed))
+		})
+	}
+}
+
+func assertSameNames(t *testing.T, kind string, expected, got []string) {
+	t.Helper()
+
+	if len(expected) != len(got) {
+		t.Fatalf("%s volumes: expected %v, got %v", kind, expected, got)
+	}
+
+	want := make(map[string]struct{}, len(expected))
+	for _, name := range expected {
+		want[name] = struct{}{}
+	}
+
+	for _, name := range got {
+		if _, ok := want[name]; !ok {
+			t.Fatalf("%s volumes: unexpected %q (expected %v, got %v)", kind, name, expected, got)
+		}
+	}
+}


### PR DESCRIPTION
## What

Allow attaching and detaching a PV-backed volume (an Aerospike namespace/device
under dynamic provisioning) on a **running** cluster, and make the operation
crash-safe.

StatefulSet `volumeClaimTemplates` are immutable, so a plain Update can't add or
remove a PV. Instead of restacking onto a brand-new STS, we orphan-delete the
existing STS (pods and PVCs keep running) and recreate it in place from the spec
(`replaceSTS`), re-adopting the orphaned pods. The change is detected by
comparing the set of `volumeClaimTemplate` names (`volumeClaimTemplatesChanged`).

Static partitioning is unaffected (the volume stays declared; only the namespace
device mapping changes). Resizing an existing PV stays out of scope and blocked.

## Commits

1. **feat: allow adding a persistent volume** — detect an added VCT, orphan-delete
   recreate the STS in place. Webhook relaxed to permit PV additions (removal
   and resize remain blocked).

2. **feat: allow removing a persistent volume** — extend the same path to removal
   (drop the VCT). Webhook now allows PV removal; it's safe with replication-factor
   ≥ 2 and the OnDelete rolling restart (data migrates off each pod before the next
   is cycled). Orphaned PVCs of removed volumes are intentionally left in place in
   v1 (no automatic cleanup).

3. **fix: crash-safe recovery of an interrupted replace** — if the operator is
   interrupted between the orphan-delete and the recreate, the next reconcile used
   to recreate the STS at size 0, making the still-running orphaned pods look
   dangling and cascade-deleting their PVCs (data loss, seen in preprod). The
   missing-STS path now uses `status.pods` (the operator's durable record of which
   pods should exist, untouched by CR re-delivery) to distinguish a brand-new rack
   from an interrupted replace, and recreates the STS sized to re-adopt every
   orphan. Covered by `TestReplaceRecoverySize`.