### PR TITLE
Fix rolling restart order after namespace storage provisioning

### DIFF
--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -1281,6 +1281,8 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 
 		// CRITEO: to repair namespace provisioning, we need to restart from the lowest ordinal upward
 		// when recreated StatefulSets adopt old pods after storage changes add new PVCs.
+		// Helper function getOrderedRackPodList is used by rack upgrade and scale down operations.
+		// Reordering the list here to not impact other operations by this fix
 		podList = reorderPodsForRollingRestart(podList)
 	}
 

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -1277,6 +1278,10 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 		if err != nil {
 			return found, common.ReconcileError(fmt.Errorf("failed to list pods: %v", err))
 		}
+
+		// CRITEO: to repair namespace provisioning, we need to restart from the lowest ordinal upward
+		// when recreated StatefulSets adopt old pods after storage changes add new PVCs.
+		podList = reorderPodsForRollingRestart(podList)
 	}
 
 	err = r.updateSTS(found, rackState)
@@ -1366,6 +1371,13 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 	)
 
 	return found, common.ReconcileSuccess()
+}
+
+func reorderPodsForRollingRestart(pods []*corev1.Pod) []*corev1.Pod {
+	reordered := slices.Clone(pods)
+	slices.Reverse(reordered)
+
+	return reordered
 }
 
 func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(

--- a/internal/controller/cluster/rack_test.go
+++ b/internal/controller/cluster/rack_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // statusPods builds a status.pods map from the given pod names.
@@ -113,5 +115,31 @@ func TestReplaceRecoverySize(t *testing.T) {
 				t.Errorf("size = %d, want %d", size, tc.wantSize)
 			}
 		})
+	}
+}
+
+func TestReorderPodsForRollingRestart(t *testing.T) {
+	pods := []*corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "aerospikes99-p02-11-2"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "aerospikes99-p02-11-1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "aerospikes99-p02-11-0"}},
+	}
+
+	reordered := reorderPodsForRollingRestart(pods)
+
+	got := getPodNames(reordered)
+	want := []string{"aerospikes99-p02-11-0", "aerospikes99-p02-11-1", "aerospikes99-p02-11-2"}
+	for idx := range want {
+		if got[idx] != want[idx] {
+			t.Fatalf("reordered pods = %v, want %v", got, want)
+		}
+	}
+
+	original := getPodNames(pods)
+	wantOriginal := []string{"aerospikes99-p02-11-2", "aerospikes99-p02-11-1", "aerospikes99-p02-11-0"}
+	for idx := range wantOriginal {
+		if original[idx] != wantOriginal[idx] {
+			t.Fatalf("original pods mutated = %v, want %v", original, wantOriginal)
+		}
 	}
 }


### PR DESCRIPTION
When adding a new namespace on clusters using dynamic disk provisioning, the operator recreates the rack StatefulSet to add new volumeClaimTemplates, then performs a rolling restart to make the new storage effective.

This can deadlock after StatefulSet re-adoption. Kubernetes checks adopted pods from lowest ordinal to highest ordinal and refuses to reconcile old pods that do not yet match the new storage spec, because pod volume definitions are immutable. The operator was deleting pods in the opposite order, from highest ordinal to lowest ordinal, which left the StatefulSet controller blocked before it could recreate later pods.

Change the rolling restart flow to restart pods from lowest ordinal upward. This matches the StatefulSet controller's reconciliation order and repairs namespace provisioning after storage changes add new PVCs.

Keep the ordering change scoped to rolling restart only, so upgrade and scale-down behavior remain unchanged.